### PR TITLE
Track queue extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ default-features = false
 optional = true
 version = "2"
 
+[dependencies.uuid]
+optional = true
+version = "0.8"
+features = ["v4"]
+
 [dependencies.xsalsa20poly1305]
 optional = true
 version = "0.6"
@@ -135,9 +140,9 @@ driver = [
     "tokio/sync",
     "tokio/time",
     "url",
+    "uuid",
     "xsalsa20poly1305",
 ]
-youtube-dlc = []
 rustls = ["async-tungstenite/tokio-rustls"]
 native = ["async-tungstenite/tokio-native-tls"]
 serenity-rustls = ["serenity/rustls_backend", "rustls", "gateway", "serenity-deps"]
@@ -148,6 +153,9 @@ twilight = ["twilight-model"]
 simd-zlib = ["twilight-gateway/simd-zlib"]
 stock-zlib = ["twilight-gateway/stock-zlib"]
 serenity-deps = ["async-trait"]
+
+youtube-dlc = []
+builtin-queue = []
 
 [[bench]]
 name = "mixing"

--- a/examples/serenity/voice_events_queue/Cargo.toml
+++ b/examples/serenity/voice_events_queue/Cargo.toml
@@ -10,6 +10,7 @@ tracing-subscriber = "0.2"
 tracing-futures = "0.2"
 
 [dependencies.songbird]
+features = ["builtin-queue"]
 path = "../../../"
 
 [dependencies.serenity]

--- a/src/tracks/handle.rs
+++ b/src/tracks/handle.rs
@@ -5,6 +5,7 @@ use tokio::sync::{
     mpsc::{error::SendError, UnboundedSender},
     oneshot,
 };
+use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 /// Handle for safe control of a [`Track`] track from other threads, outside
@@ -18,6 +19,7 @@ use tokio::sync::{
 pub struct TrackHandle {
     command_channel: UnboundedSender<TrackCommand>,
     seekable: bool,
+    uuid: Uuid,
 }
 
 impl TrackHandle {
@@ -25,10 +27,11 @@ impl TrackHandle {
     /// the underlying [`Input`] supports seek operations.
     ///
     /// [`Input`]: ../input/struct.Input.html
-    pub fn new(command_channel: UnboundedSender<TrackCommand>, seekable: bool) -> Self {
+    pub fn new(command_channel: UnboundedSender<TrackCommand>, seekable: bool, uuid: Uuid) -> Self {
         Self {
             command_channel,
             seekable,
+            uuid,
         }
     }
 
@@ -147,6 +150,11 @@ impl TrackHandle {
         } else {
             Err(SendError(TrackCommand::Loop(LoopState::Finite(count))))
         }
+    }
+
+    /// Returns this handle's (and track's) unique identifier.
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
     }
 
     #[inline]


### PR DESCRIPTION
In response to and/or closes #3.

* Adds a uuid field to tracks and handles to make it easier to identify and match event sources after the fact.
* Adds optional feature "builtin-queue" to expose a queue on every driver, as a convenience for users who can guarantee they'll need a queue for every driver/call.
* Adds methods to queues to allow access to the currently running track handle, remove a specified queue entry, as well as to mutate the underlying queue from a closure.