### PR TITLE
Input: Make restartable sources fully async

### DIFF
--- a/examples/twilight/src/main.rs
+++ b/examples/twilight/src/main.rs
@@ -184,7 +184,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
     let guild_id = msg.guild_id.unwrap();
 
-    if let Ok(song) = Restartable::ytdl(msg.content.clone()) {
+    if let Ok(song) = Restartable::ytdl(msg.content.clone()).await {
         let input = Input::from(song);
 
         let content = format!(


### PR DESCRIPTION
Redresses a previous holdover from an attempt to get Restartable sources to work more neatly inside the synchronous mixer thread. This prevents `Restartable::*` from blocking without warning.

The initial fix at the time was to perform the restart work on a task provided by the tokio runtime as `executor::block_on` needs to be run from within a valid async runtime. Naturally, this completely missed the point that these closures should/could be async, without any need to fudge async functions into a sync wrapper.

Also removes the `From` for normal closures, as this will probably act as a footgun for folks on a single-threaded executor.

Closes #13.