### PR TITLE
Add function to return a vector of all the handles in a queue

### DIFF
--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -114,7 +114,7 @@ impl EventHandler for QueueHandler {
                 let ended_uuid = ts.first().map(|handle| handle.1.uuid());
 
                 queue_uuid.is_some() && queue_uuid == ended_uuid
-            }
+            },
             _ => false,
         };
 

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -284,6 +284,8 @@ impl TrackQueue {
     /// Does not allow for modification of the queue, instead returns a snapshot of the queue at the time of calling.
     ///
     /// Use [`modify_queue`] for direct modification of the queue.
+    ///
+    /// [`modify_queue`]: #method.modify_queue
     pub fn current_queue(&self) -> Vec<TrackHandle> {
         let inner = self.inner.lock();
 

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -114,7 +114,7 @@ impl EventHandler for QueueHandler {
                 let ended_uuid = ts.first().map(|handle| handle.1.uuid());
 
                 queue_uuid.is_some() && queue_uuid == ended_uuid
-            },
+            }
             _ => false,
         };
 
@@ -277,6 +277,13 @@ impl TrackQueue {
         let inner = self.inner.lock();
 
         inner.stop_current()
+    }
+
+    /// Returns Vec of all handles in queue
+    pub fn to_vec(&self) -> Vec<TrackHandle> {
+        let inner = self.inner.lock();
+
+        inner.tracks.iter().map(|q| q.handle()).collect()
     }
 }
 

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -279,8 +279,12 @@ impl TrackQueue {
         inner.stop_current()
     }
 
-    /// Returns Vec of all handles in queue
-    pub fn to_vec(&self) -> Vec<TrackHandle> {
+    /// Returns a list of currently queued tracks.
+    ///
+    /// Does not allow for modification of the queue, instead returns a snapshot of the queue at the time of calling.
+    ///
+    /// Use [`modify_queue`] for direct modification of the queue.
+    pub fn current_queue(&self) -> Vec<TrackHandle> {
         let inner = self.inner.lock();
 
         inner.tracks.iter().map(|q| q.handle()).collect()


### PR DESCRIPTION
Basically, an extension to current() but returns a vector of all the handles in a queue