### PR TITLE
Fixed serenity dependency default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ version = "0.7"
 
 [dependencies.serenity]
 optional = true
+default-features = false
 features = ["voice", "gateway"]
 git = "https://github.com/serenity-rs/serenity"
 branch = "current"


### PR DESCRIPTION
This change is needed to fix this issue in serenity when using songbird.
```
thread 'main' panicked at 'The `framework`-feature is enabled (it's on by default), but no framework was provided.
If you don't want to use the command framework, disable default features and specify all features you want to use.'
```