### PR TITLE
Cleanup of leaky types, nested results

### DIFF
--- a/examples/twilight/src/main.rs
+++ b/examples/twilight/src/main.rs
@@ -127,10 +127,9 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
     let (_handle, success) = state.songbird.join(guild_id, channel_id).await;
 
-    let content = match success?.recv_async().await {
-        Ok(Ok(())) => format!("Joined <#{}>!", channel_id),
-        Ok(Err(e)) => format!("Failed to join <#{}>! Why: {:?}", channel_id, e),
-        _ => format!("Failed to join <#{}>: Gateway error!", channel_id),
+    let content = match success {
+        Ok(()) => format!("Joined <#{}>!", channel_id),
+        Err(e) => format!("Failed to join <#{}>! Why: {:?}", channel_id, e),
     };
 
     state
@@ -237,7 +236,7 @@ async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
     let store = state.trackdata.read().await;
 
     let content = if let Some(handle) = store.get(&guild_id) {
-        let info = handle.get_info()?.await?;
+        let info = handle.get_info().await?;
 
         let paused = match info.playing {
             PlayMode::Play => {

--- a/src/driver/connection/error.rs
+++ b/src/driver/connection/error.rs
@@ -11,7 +11,11 @@ use xsalsa20poly1305::aead::Error as CryptoError;
 
 /// Errors encountered while connecting to a Discord voice server over the driver.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
+    /// The driver hung up an internal signaller, either due to another connection attempt
+    /// or a crash.
+    AttemptDiscarded,
     /// An error occurred during [en/de]cryption of voice packets or key generation.
     Crypto(CryptoError),
     /// Server did not return the expected crypto mode during negotiation.
@@ -83,6 +87,7 @@ impl fmt::Display for Error {
         write!(f, "Failed to connect to Discord RTP server: ")?;
         use Error::*;
         match self {
+            AttemptDiscarded => write!(f, "connection attempt was aborted/discarded."),
             Crypto(c) => write!(f, "cryptography error {}.", c),
             CryptoModeInvalid => write!(f, "server changed negotiated encryption mode."),
             CryptoModeUnavailable => write!(f, "server did not offer chosen encryption mode."),

--- a/src/driver/tasks/mixer.rs
+++ b/src/driver/tasks/mixer.rs
@@ -322,7 +322,7 @@ impl Mixer {
             if temp_len > 0 || opus_len.is_some() {
                 track.step_frame();
             } else if track.do_loop() {
-                if let Some(time) = track.seek_time(Default::default()) {
+                if let Ok(time) = track.seek_time(Default::default()) {
                     // have to reproduce self.fire_event here
                     // to circumvent the borrow checker's lack of knowledge.
                     //

--- a/src/input/ffmpeg_src.rs
+++ b/src/input/ffmpeg_src.rs
@@ -15,6 +15,12 @@ use tokio::process::Command as TokioCommand;
 use tracing::debug;
 
 /// Opens an audio file through `ffmpeg` and creates an audio source.
+///
+/// This source is not seek-compatible.
+/// If you need looping or track seeking, then consider using
+/// [`Restartable::ffmpeg`].
+///
+/// [`Restartable::ffmpeg`]: crate::input::restartable::Restartable::ffmpeg
 pub async fn ffmpeg<P: AsRef<OsStr>>(path: P) -> Result<Input> {
     _ffmpeg(path.as_ref()).await
 }

--- a/src/input/ytdl_src.rs
+++ b/src/input/ytdl_src.rs
@@ -22,7 +22,13 @@ const YOUTUBE_DL_COMMAND: &str = if cfg!(feature = "youtube-dlc") {
 
 /// Creates a streamed audio source with `youtube-dl` and `ffmpeg`.
 ///
-/// Uses `youtube-dlc` if the `youtube-dlc` feature is enabled.
+/// This source is not seek-compatible.
+/// If you need looping or track seeking, then consider using
+/// [`Restartable::ytdl`].
+///
+/// Uses `youtube-dlc` if the `"youtube-dlc"` feature is enabled.
+///
+/// [`Restartable::ytdl`]: crate::input::restartable::Restartable::ytdl
 pub async fn ytdl(uri: &str) -> Result<Input> {
     _ytdl(uri, &[]).await
 }
@@ -110,6 +116,14 @@ pub(crate) async fn _ytdl(uri: &str, pre_args: &[&str]) -> Result<Input> {
 
 /// Creates a streamed audio source from YouTube search results with `youtube-dl(c)`,`ffmpeg`, and `ytsearch`.
 /// Takes the first video listed from the YouTube search.
+///
+/// This source is not seek-compatible.
+/// If you need looping or track seeking, then consider using
+/// [`Restartable::ytdl_search`].
+///
+/// Uses `youtube-dlc` if the `"youtube-dlc"` feature is enabled.
+///
+/// [`Restartable::ytdl_search`]: crate::input::restartable::Restartable::ytdl_search
 pub async fn ytdl_search(name: &str) -> Result<Input> {
     ytdl(&format!("ytsearch1:{}", name)).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "gateway")]
-pub use crate::{handler::Call, manager::Songbird};
+pub use crate::{handler::*, manager::*};
 
 #[cfg(feature = "serenity")]
 pub use crate::serenity::*;

--- a/src/tracks/error.rs
+++ b/src/tracks/error.rs
@@ -1,0 +1,39 @@
+use std::{error::Error, fmt};
+
+/// Errors associated with control and manipulation of tracks.
+///
+/// Unless otherwise stated, these don't invalidate an existing track,
+/// but do advise on valid operations and commands.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum TrackError {
+    /// The operation failed because the track has ended, has been removed
+    /// due to call closure, or some error within the driver.
+    Finished,
+    /// The supplied event listener can never be fired by a track, and should
+    /// be attached to the driver instead.
+    InvalidTrackEvent,
+    /// The track's underlying [`Input`] doesn't support seeking operations.
+    ///
+    /// [`Input`]: crate::input::Input
+    SeekUnsupported,
+}
+
+impl fmt::Display for TrackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to operate on track (handle): ")?;
+        match self {
+            TrackError::Finished => write!(f, "track ended."),
+            TrackError::InvalidTrackEvent =>
+                write!(f, "given event listener can't be fired on a track."),
+            TrackError::SeekUnsupported => write!(f, "track did not support seeking."),
+        }
+    }
+}
+
+impl Error for TrackError {}
+
+/// Alias for most calls to a [`TrackHandle`].
+///
+/// [`TrackHandle`]: super::TrackHandle
+pub type TrackResult<T> = Result<T, TrackError>;

--- a/src/tracks/handle.rs
+++ b/src/tracks/handle.rs
@@ -1,10 +1,7 @@
 use super::*;
 use crate::events::{Event, EventData, EventHandler};
 use std::time::Duration;
-use tokio::sync::{
-    mpsc::{error::SendError, UnboundedSender},
-    oneshot,
-};
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use uuid::Uuid;
 
 #[derive(Clone, Debug)]
@@ -36,12 +33,12 @@ impl TrackHandle {
     }
 
     /// Unpauses an audio track.
-    pub fn play(&self) -> TrackResult {
+    pub fn play(&self) -> TrackResult<()> {
         self.send(TrackCommand::Play)
     }
 
     /// Pauses an audio track.
-    pub fn pause(&self) -> TrackResult {
+    pub fn pause(&self) -> TrackResult<()> {
         self.send(TrackCommand::Pause)
     }
 
@@ -51,12 +48,12 @@ impl TrackHandle {
     /// a [`TrackEvent::End`] event.
     ///
     /// [`TrackEvent::End`]: crate::events::TrackEvent::End
-    pub fn stop(&self) -> TrackResult {
+    pub fn stop(&self) -> TrackResult<()> {
         self.send(TrackCommand::Stop)
     }
 
     /// Sets the volume of an audio track.
-    pub fn set_volume(&self, volume: f32) -> TrackResult {
+    pub fn set_volume(&self, volume: f32) -> TrackResult<()> {
         self.send(TrackCommand::Volume(volume))
     }
 
@@ -73,43 +70,43 @@ impl TrackHandle {
 
     /// Seeks along the track to the specified position.
     ///
-    /// If the underlying [`Input`] does not support this behaviour,
-    /// then all calls will fail.
+    /// If the underlying [`Input`] does not support seeking,
+    /// then all calls will fail with [`TrackError::SeekUnsupported`].
     ///
     /// [`Input`]: crate::input::Input
-    pub fn seek_time(&self, position: Duration) -> TrackResult {
+    /// [`TrackError::SeekUnsupported`]: TrackError::SeekUnsupported
+    pub fn seek_time(&self, position: Duration) -> TrackResult<()> {
         if self.seekable {
             self.send(TrackCommand::Seek(position))
         } else {
-            Err(SendError(TrackCommand::Seek(position)))
+            Err(TrackError::SeekUnsupported)
         }
     }
 
     /// Attach an event handler to an audio track. These will receive [`EventContext::Track`].
     ///
-    /// Users **must** ensure that no costly work or blocking occurs
-    /// within the supplied function or closure. *Taking excess time could prevent
-    /// timely sending of packets, causing audio glitches and delays*.
+    /// Events which can only be fired by the global context return [`TrackError::InvalidTrackEvent`]
     ///
     /// [`Track`]: Track
     /// [`EventContext::Track`]: crate::events::EventContext::Track
-    pub fn add_event<F: EventHandler + 'static>(&self, event: Event, action: F) -> TrackResult {
+    /// [`TrackError::InvalidTrackEvent`]: TrackError::InvalidTrackEvent
+    pub fn add_event<F: EventHandler + 'static>(&self, event: Event, action: F) -> TrackResult<()> {
         let cmd = TrackCommand::AddEvent(EventData::new(event, action));
         if event.is_global_only() {
-            Err(SendError(cmd))
+            Err(TrackError::InvalidTrackEvent)
         } else {
             self.send(cmd)
         }
     }
 
-    /// Perform an arbitrary action on a raw [`Track`] object.
+    /// Perform an arbitrary synchronous action on a raw [`Track`] object.
     ///
     /// Users **must** ensure that no costly work or blocking occurs
     /// within the supplied function or closure. *Taking excess time could prevent
     /// timely sending of packets, causing audio glitches and delays*.
     ///
     /// [`Track`]: Track
-    pub fn action<F>(&self, action: F) -> TrackResult
+    pub fn action<F>(&self, action: F) -> TrackResult<()>
     where
         F: FnOnce(&mut Track) + Send + Sync + 'static,
     {
@@ -117,38 +114,55 @@ impl TrackHandle {
     }
 
     /// Request playback information and state from the audio context.
-    ///
-    /// Crucially, the audio thread will respond *at a later time*:
-    /// It is up to the user when or how this should be read from the returned channel.
-    pub fn get_info(&self) -> TrackQueryResult {
+    pub async fn get_info(&self) -> TrackResult<Box<TrackState>> {
         let (tx, rx) = oneshot::channel();
-        self.send(TrackCommand::Request(tx)).map(move |_| rx)
+        self.send(TrackCommand::Request(tx))?;
+
+        rx.await.map_err(|_| TrackError::Finished)
     }
 
     /// Set an audio track to loop indefinitely.
-    pub fn enable_loop(&self) -> TrackResult {
+    ///
+    /// If the underlying [`Input`] does not support seeking,
+    /// then all calls will fail with [`TrackError::SeekUnsupported`].
+    ///
+    /// [`Input`]: crate::input::Input
+    /// [`TrackError::SeekUnsupported`]: TrackError::SeekUnsupported
+    pub fn enable_loop(&self) -> TrackResult<()> {
         if self.seekable {
             self.send(TrackCommand::Loop(LoopState::Infinite))
         } else {
-            Err(SendError(TrackCommand::Loop(LoopState::Infinite)))
+            Err(TrackError::SeekUnsupported)
         }
     }
 
     /// Set an audio track to no longer loop.
-    pub fn disable_loop(&self) -> TrackResult {
+    ///
+    /// If the underlying [`Input`] does not support seeking,
+    /// then all calls will fail with [`TrackError::SeekUnsupported`].
+    ///
+    /// [`Input`]: crate::input::Input
+    /// [`TrackError::SeekUnsupported`]: TrackError::SeekUnsupported
+    pub fn disable_loop(&self) -> TrackResult<()> {
         if self.seekable {
             self.send(TrackCommand::Loop(LoopState::Finite(0)))
         } else {
-            Err(SendError(TrackCommand::Loop(LoopState::Finite(0))))
+            Err(TrackError::SeekUnsupported)
         }
     }
 
     /// Set an audio track to loop a set number of times.
-    pub fn loop_for(&self, count: usize) -> TrackResult {
+    ///
+    /// If the underlying [`Input`] does not support seeking,
+    /// then all calls will fail with [`TrackError::SeekUnsupported`].
+    ///
+    /// [`Input`]: crate::input::Input
+    /// [`TrackError::SeekUnsupported`]: TrackError::SeekUnsupported
+    pub fn loop_for(&self, count: usize) -> TrackResult<()> {
         if self.seekable {
             self.send(TrackCommand::Loop(LoopState::Finite(count)))
         } else {
-            Err(SendError(TrackCommand::Loop(LoopState::Finite(count))))
+            Err(TrackError::SeekUnsupported)
         }
     }
 
@@ -161,7 +175,11 @@ impl TrackHandle {
     /// Send a raw command to the [`Track`] object.
     ///
     /// [`Track`]: Track
-    pub fn send(&self, cmd: TrackCommand) -> TrackResult {
-        self.command_channel.send(cmd)
+    pub fn send(&self, cmd: TrackCommand) -> TrackResult<()> {
+        // As the send channels are unbounded, we can be reasonably certain
+        // that send failure == cancellation.
+        self.command_channel
+            .send(cmd)
+            .map_err(|_e| TrackError::Finished)
     }
 }

--- a/src/tracks/mod.rs
+++ b/src/tracks/mod.rs
@@ -15,24 +15,18 @@
 //! [`create_player`]: fn.create_player.html
 
 mod command;
+mod error;
 mod handle;
 mod looping;
 mod mode;
 mod queue;
 mod state;
 
-pub use self::{command::*, handle::*, looping::*, mode::*, queue::*, state::*};
+pub use self::{command::*, error::*, handle::*, looping::*, mode::*, queue::*, state::*};
 
 use crate::{constants::*, driver::tasks::message::*, events::EventStore, input::Input};
 use std::time::Duration;
-use tokio::sync::{
-    mpsc::{
-        self,
-        error::{SendError, TryRecvError},
-        UnboundedReceiver,
-    },
-    oneshot::Receiver as OneshotReceiver,
-};
+use tokio::sync::mpsc::{self, error::TryRecvError, UnboundedReceiver};
 use uuid::Uuid;
 
 /// Control object for audio playback.
@@ -63,18 +57,18 @@ use uuid::Uuid;
 /// # };
 /// ```
 ///
-/// [`Driver::play_only`]: ../struct.Driver.html#method.play_only
-/// [`Driver::play`]: ../struct.Driver.html#method.play
-/// [`TrackHandle`]: struct.TrackHandle.html
-/// [`create_player`]: fn.create_player.html
+/// [`Driver::play_only`]: crate::driver::Driver::play_only
+/// [`Driver::play`]: crate::driver::Driver::play
+/// [`TrackHandle`]: TrackHandle
+/// [`create_player`]: create_player
 #[derive(Debug)]
 pub struct Track {
     /// Whether or not this sound is currently playing.
     ///
     /// Can be controlled with [`play`] or [`pause`] if chaining is desired.
     ///
-    /// [`play`]: #method.play
-    /// [`pause`]: #method.pause
+    /// [`play`]: Track::play
+    /// [`pause`]: Track::pause
     pub(crate) playing: PlayMode,
 
     /// The desired volume for playback.
@@ -83,7 +77,7 @@ pub struct Track {
     ///
     /// Can be controlled with [`volume`] if chaining is desired.
     ///
-    /// [`volume`]: #method.volume
+    /// [`volume`]: Track::volume
     pub(crate) volume: f32,
 
     /// Underlying data access object.
@@ -187,7 +181,7 @@ impl Track {
 
     /// Sets [`volume`] in a manner that allows method chaining.
     ///
-    /// [`volume`]: #structfield.volume
+    /// [`volume`]: Track::volume
     pub fn set_volume(&mut self, volume: f32) -> &mut Self {
         self.volume = volume;
 
@@ -209,12 +203,20 @@ impl Track {
         self.play_time
     }
 
-    /// Sets [`loops`] in a manner that allows method chaining.
+    /// Set an audio track to loop a set number of times.
     ///
-    /// [`loops`]: #structfield.loops
-    pub fn set_loops(&mut self, loops: LoopState) -> &mut Self {
-        self.loops = loops;
-        self
+    /// If the underlying [`Input`] does not support seeking,
+    /// then all calls will fail with [`TrackError::SeekUnsupported`].
+    ///
+    /// [`Input`]: crate::input::Input
+    /// [`TrackError::SeekUnsupported`]: TrackError::SeekUnsupported
+    pub fn set_loops(&mut self, loops: LoopState) -> TrackResult<()> {
+        if self.source.is_seekable() {
+            self.loops = loops;
+            Ok(())
+        } else {
+            Err(TrackError::SeekUnsupported)
+        }
     }
 
     pub(crate) fn do_loop(&mut self) -> bool {
@@ -234,11 +236,9 @@ impl Track {
         self.play_time += TIMESTEP_LENGTH;
     }
 
-    /// Receives and acts upon any commands forwarded by [`TrackHandle`]s.
+    /// Receives and acts upon any commands forwarded by TrackHandles.
     ///
     /// *Used internally*, this should not be exposed to users.
-    ///
-    /// [`TrackHandle`]: struct.TrackHandle.html
     pub(crate) fn process_commands(&mut self, index: usize, ic: &Interconnect) {
         // Note: disconnection and an empty channel are both valid,
         // and should allow the audio object to keep running as intended.
@@ -280,13 +280,13 @@ impl Track {
                                 TrackStateChange::Volume(self.volume),
                             ));
                         },
-                        Seek(time) => {
-                            self.seek_time(time);
-                            let _ = ic.events.send(EventMessage::ChangeState(
-                                index,
-                                TrackStateChange::Position(self.position),
-                            ));
-                        },
+                        Seek(time) =>
+                            if let Ok(new_time) = self.seek_time(time) {
+                                let _ = ic.events.send(EventMessage::ChangeState(
+                                    index,
+                                    TrackStateChange::Position(new_time),
+                                ));
+                            },
                         AddEvent(evt) => {
                             let _ = ic.events.send(EventMessage::AddTrackEvent(index, evt));
                         },
@@ -300,13 +300,13 @@ impl Track {
                         Request(tx) => {
                             let _ = tx.send(Box::new(self.state()));
                         },
-                        Loop(loops) => {
-                            self.set_loops(loops);
-                            let _ = ic.events.send(EventMessage::ChangeState(
-                                index,
-                                TrackStateChange::Loops(self.loops, true),
-                            ));
-                        },
+                        Loop(loops) =>
+                            if self.set_loops(loops).is_ok() {
+                                let _ = ic.events.send(EventMessage::ChangeState(
+                                    index,
+                                    TrackStateChange::Loops(self.loops, true),
+                                ));
+                            },
                     }
                 },
                 Err(TryRecvError::Closed) => {
@@ -325,7 +325,7 @@ impl Track {
     /// The primary use-case of this is sending information across
     /// threads in response to a [`TrackHandle`].
     ///
-    /// [`TrackHandle`]: struct.TrackHandle.html
+    /// [`TrackHandle`]: TrackHandle
     pub fn state(&self) -> TrackState {
         TrackState {
             playing: self.playing,
@@ -338,15 +338,18 @@ impl Track {
 
     /// Seek to a specific point in the track.
     ///
-    /// Returns `None` if unsupported.
-    pub fn seek_time(&mut self, pos: Duration) -> Option<Duration> {
-        let out = self.source.seek_time(pos);
-
-        if let Some(t) = out {
+    /// If the underlying [`Input`] does not support seeking,
+    /// then all calls will fail with [`TrackError::SeekUnsupported`].
+    ///
+    /// [`Input`]: crate::input::Input
+    /// [`TrackError::SeekUnsupported`]: TrackError::SeekUnsupported
+    pub fn seek_time(&mut self, pos: Duration) -> TrackResult<Duration> {
+        if let Some(t) = self.source.seek_time(pos) {
             self.position = t;
+            Ok(t)
+        } else {
+            Err(TrackError::SeekUnsupported)
         }
-
-        out
     }
 
     /// Returns this track's unique identifier.
@@ -372,22 +375,3 @@ pub fn create_player(source: Input) -> (Track, TrackHandle) {
 
     (player, handle)
 }
-
-/// Alias for most result-free calls to a [`TrackHandle`].
-///
-/// Failure indicates that the accessed audio object has been
-/// removed or deleted by the audio context.
-///
-/// [`TrackHandle`]: TrackHandle
-pub type TrackResult = Result<(), SendError<TrackCommand>>;
-
-/// Alias for return value from calls to [`TrackHandle::get_info`].
-///
-/// Crucially, the audio thread will respond *at a later time*:
-/// It is up to the user when or how this should be read from the returned channel.
-///
-/// Failure indicates that the accessed audio object has been
-/// removed or deleted by the audio context.
-///
-/// [`TrackHandle::get_info`]: TrackHandle::get_info
-pub type TrackQueryResult = Result<OneshotReceiver<Box<TrackState>>, SendError<TrackCommand>>;

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -240,7 +240,7 @@ impl TrackQueue {
     }
 
     /// Pause the track at the head of the queue.
-    pub fn pause(&self) -> TrackResult {
+    pub fn pause(&self) -> TrackResult<()> {
         let inner = self.inner.lock();
 
         if let Some(handle) = inner.tracks.front() {
@@ -251,7 +251,7 @@ impl TrackQueue {
     }
 
     /// Resume the track at the head of the queue.
-    pub fn resume(&self) -> TrackResult {
+    pub fn resume(&self) -> TrackResult<()> {
         let inner = self.inner.lock();
 
         if let Some(handle) = inner.tracks.front() {
@@ -273,7 +273,7 @@ impl TrackQueue {
     }
 
     /// Skip to the next track in the queue, if it exists.
-    pub fn skip(&self) -> TrackResult {
+    pub fn skip(&self) -> TrackResult<()> {
         let inner = self.inner.lock();
 
         inner.stop_current()
@@ -295,7 +295,7 @@ impl TrackQueue {
 
 impl TrackQueueCore {
     /// Skip to the next track in the queue, if it exists.
-    fn stop_current(&self) -> TrackResult {
+    fn stop_current(&self) -> TrackResult<()> {
         if let Some(handle) = self.tracks.front() {
             handle.stop()
         } else {


### PR DESCRIPTION
Main goal: a lot of nested future/result folding.

This mainly modifies error handling for Tracks and TrackHandles to be
more consistent, and hides the underlying channel result passing in
get_info. Errors returned should be far clearer, and are domain
specific rather than falling back to a very opaque use of the underlying
channel error. It should be clearer to users why their handle commands
failed, or why they can't make a ytdl track loop or similar.

Also fixed/cleaned up Songbird::join(_gateway) to return in a single
await, sparing the user from the underlying channel details and repeated
Errs. I was trying for some time to extend the same graces to `Call`,
but could not figure out a sane way to get a 'static version of the
first future in the chain (i.e., the gateway send) so that the whole
thing could happen after dropping the lock around the Call. I really
wanted to fix this to happen as a single folded await too, but I think
this might need some crazy hack or redesign.

Probably closes #10 and closes #11.