### PR TITLE
handle youtube-dl metadata parsing errors + Json parsing errors now contain the parsed text

### DIFF
--- a/src/input/error.rs
+++ b/src/input/error.rs
@@ -16,7 +16,12 @@ pub enum Error {
     /// An error occurred while reading, or opening a file.
     Io(IoError),
     /// An error occurred while parsing JSON (i.e., during metadata/stereo detection).
-    Json(JsonError),
+    Json {
+        /// Json error
+        error: JsonError,
+        /// Text that failed to be parsed
+        parsed_text: String,
+    },
     /// An error occurred within the Opus codec.
     Opus(OpusError),
     /// Failed to extract metadata from alternate pipe.
@@ -54,12 +59,6 @@ impl From<DcaError> for Error {
 impl From<IoError> for Error {
     fn from(e: IoError) -> Error {
         Error::Io(e)
-    }
-}
-
-impl From<JsonError> for Error {
-    fn from(e: JsonError) -> Self {
-        Error::Json(e)
     }
 }
 

--- a/src/input/ffmpeg_src.rs
+++ b/src/input/ffmpeg_src.rs
@@ -140,7 +140,12 @@ pub(crate) async fn is_stereo(path: &OsStr) -> Result<(bool, Metadata)> {
         .output()
         .await?;
 
-    let value: Value = serde_json::from_reader(&out.stdout[..])?;
+    let value: Value = serde_json::from_reader(&out.stdout[..]).map_err(|err| Error::Json {
+        error: err,
+        parsed_text: std::str::from_utf8(&out.stdout[..])
+            .unwrap_or_default()
+            .to_string(),
+    })?;
 
     let metadata = Metadata::from_ffprobe_json(&value);
 


### PR DESCRIPTION
When youtube-dl is outdated it will fail to download some videos. Serenity handles this by silently ignoring the issue, leading to confusion. 
This PR changes the youtube-dl metadata parsing to return an `Error::Json` when it fails to parse and also stores the parsed text in `Error::Json`.

With this PR when the serenity voice example is run with the old version of youtube-dl the following is output on some videos:
```Err starting source: Json { error: Error("expected value", line: 1, column: 1), parsed_text: "ERROR: "token" parameter not in video info for unknown reason; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.\n" }```
This indicates to the user how to fix the problem. i.e. update youtube-dl
Previously the example reported that it was playing the song even when the video failed to load due to outdated youtube-dl resulting in no audio output.