### PR TITLE
Songbird: Tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "0.1"
 default-features = false
 features = ["tokio-runtime"]
 optional = true
-version = "0.9"
+version = "0.11"
 
 [dependencies.audiopus]
 optional = true
@@ -58,6 +58,7 @@ version = "0.8"
 
 [dependencies.serenity]
 optional = true
+#version = "0.10"
 default-features = false
 features = ["voice", "gateway"]
 git = "https://github.com/serenity-rs/serenity"
@@ -65,6 +66,7 @@ branch = "current"
 
 [dependencies.serenity-voice-model]
 optional = true
+#version = "0.10"
 git = "https://github.com/serenity-rs/serenity"
 branch = "current"
 
@@ -78,18 +80,22 @@ version = "0.1"
 
 [dependencies.tokio]
 optional = true
-version = "0.2"
+version = "1.0"
 default-features = false
 
 [dependencies.twilight-gateway]
 optional = true
-version = "0.2"
+#version = "0.3"
 default-features = false
+git = "https://github.com/twilight-rs/twilight"
+branch = "v0.3"
 
 [dependencies.twilight-model]
 optional = true
-version = "0.2"
+#version = "0.3"
 default-features = false
+git = "https://github.com/twilight-rs/twilight"
+branch = "v0.3"
 
 [dependencies.typemap_rev]
 optional = true
@@ -135,13 +141,12 @@ driver = [
     "serenity-voice-model",
     "spin_sleep",
     "streamcatcher",
-    "tokio/blocking",
     "tokio/fs",
     "tokio/io-util",
     "tokio/macros",
     "tokio/net",
     "tokio/process",
-    "tokio/rt-core",
+    "tokio/rt",
     "tokio/sync",
     "tokio/time",
     "typemap_rev",

--- a/examples/serenity/voice/Cargo.toml
+++ b/examples/serenity/voice/Cargo.toml
@@ -18,5 +18,5 @@ git = "https://github.com/serenity-rs/serenity"
 branch = "current"
 
 [dependencies.tokio]
-version = "0.2"
-features = ["macros"]
+version = "1.0"
+features = ["macros", "rt-multi-thread"]

--- a/examples/serenity/voice_events_queue/Cargo.toml
+++ b/examples/serenity/voice_events_queue/Cargo.toml
@@ -19,5 +19,5 @@ git = "https://github.com/serenity-rs/serenity"
 branch = "current"
 
 [dependencies.tokio]
-version = "0.2"
-features = ["macros"]
+version = "1.0"
+features = ["macros", "rt-multi-thread"]

--- a/examples/serenity/voice_receive/Cargo.toml
+++ b/examples/serenity/voice_receive/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["my name <my@email.address>"]
 edition = "2018"
 
 [dependencies]
-env_logger = "~0.6"
-log = "~0.4"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+tracing-futures = "0.2"
 
 [dependencies.songbird]
 path = "../../../"
@@ -17,5 +18,5 @@ git = "https://github.com/serenity-rs/serenity"
 branch = "current"
 
 [dependencies.tokio]
-version = "0.2"
-features = ["macros"]
+version = "1.0"
+features = ["macros", "rt-multi-thread"]

--- a/examples/serenity/voice_receive/src/main.rs
+++ b/examples/serenity/voice_receive/src/main.rs
@@ -153,6 +153,8 @@ struct General;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
+    
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN")
         .expect("Expected a token in the environment");

--- a/examples/serenity/voice_storage/Cargo.toml
+++ b/examples/serenity/voice_storage/Cargo.toml
@@ -18,5 +18,5 @@ git = "https://github.com/serenity-rs/serenity"
 branch = "current"
 
 [dependencies.tokio]
-version = "0.2"
-features = ["macros"]
+version = "1.0"
+features = ["macros", "rt-multi-thread"]

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -9,11 +9,11 @@ futures = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 serde_json = { version = "1" }
-tokio = { features = ["macros", "rt-threaded", "sync"], version = "0.2" }
-twilight-gateway = "0.2"
-twilight-http = "0.2"
-twilight-model = "0.2"
-twilight-standby = "0.2"
+tokio = { features = ["macros", "rt-multi-thread", "sync"], version = "1" }
+twilight-gateway = { git = "https://github.com/twilight-rs/twilight", branch = "v0.3" }
+twilight-http = { git = "https://github.com/twilight-rs/twilight", branch = "v0.3" }
+twilight-model = { git = "https://github.com/twilight-rs/twilight", branch = "v0.3" }
+twilight-standby = { git = "https://github.com/twilight-rs/twilight", branch = "v0.3" }
 
 [dependencies.songbird]
 path = "../.."

--- a/src/driver/tasks/udp_rx.rs
+++ b/src/driver/tasks/udp_rx.rs
@@ -20,8 +20,8 @@ use discortp::{
     PacketSize,
 };
 use flume::Receiver;
-use std::collections::HashMap;
-use tokio::net::udp::RecvHalf;
+use std::{collections::HashMap, sync::Arc};
+use tokio::net::UdpSocket;
 use tracing::{error, info, instrument, warn};
 use xsalsa20poly1305::XSalsa20Poly1305 as Cipher;
 
@@ -236,7 +236,7 @@ struct UdpRx {
     config: Config,
     packet_buffer: [u8; VOICE_PACKET_MAX],
     rx: Receiver<UdpRxMessage>,
-    udp_socket: RecvHalf,
+    udp_socket: Arc<UdpSocket>,
 }
 
 impl UdpRx {
@@ -391,7 +391,7 @@ pub(crate) async fn runner(
     rx: Receiver<UdpRxMessage>,
     cipher: Cipher,
     config: Config,
-    udp_socket: RecvHalf,
+    udp_socket: Arc<UdpSocket>,
 ) {
     info!("UDP receive handle started.");
 

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -57,7 +57,7 @@ impl AuxNetwork {
             let mut ws_error = false;
             let mut should_reconnect = false;
 
-            let hb = time::delay_until(next_heartbeat);
+            let hb = time::sleep_until(next_heartbeat);
 
             tokio::select! {
                 _ = hb => {

--- a/src/tracks/command.rs
+++ b/src/tracks/command.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::events::EventData;
+use flume::Sender;
 use std::time::Duration;
-use tokio::sync::oneshot::Sender as OneshotSender;
 
 /// A request from external code using a [`TrackHandle`] to modify
 /// or act upon an [`Track`] object.
@@ -27,7 +27,7 @@ pub enum TrackCommand {
     /// Run some closure on this track, with direct access to the core object.
     Do(Box<dyn FnOnce(&mut Track) + Send + Sync + 'static>),
     /// Request a read-only view of this track's state.
-    Request(OneshotSender<Box<TrackState>>),
+    Request(Sender<Box<TrackState>>),
     /// Change the loop count/strategy of this track.
     Loop(LoopState),
     /// Prompts a track's input to become live and usable, if it is not already.


### PR DESCRIPTION
Migrates to the new version of tokio, requiring full channel migration to flume, and sleep changes in a few locations. Additionally points to the in-tree v0.3 version of twilight.

Closes #35.