### PR TITLE
Input & Driver: Fix zombie processes on Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ version = "0.10"
 [dependencies.futures]
 version = "0.3"
 
+[dependencies.nix]
+version = "0.19"
+optional = true
+
 [dependencies.parking_lot]
 optional = true
 version = "0.11"
@@ -133,6 +137,7 @@ driver = [
     "byteorder",
     "discortp",
     "flume",
+    "nix",
     "parking_lot",
     "rand",
     "serenity-voice-model",

--- a/src/driver/tasks/disposal.rs
+++ b/src/driver/tasks/disposal.rs
@@ -1,0 +1,18 @@
+use super::message::*;
+use flume::Receiver;
+use tracing::instrument;
+
+/// The mixer's disposal thread is also synchronous, due to tracks,
+/// inputs, etc. being based on synchronous I/O.
+///
+/// The mixer uses this to offload heavy and expensive drop operations
+/// to prevent deadline misses.
+#[instrument(skip(mix_rx))]
+pub(crate) fn runner(mix_rx: Receiver<DisposalMessage>) {
+    loop {
+        match mix_rx.recv() {
+            Err(_) | Ok(DisposalMessage::Poison) => break,
+            _ => {},
+        }
+    }
+}

--- a/src/driver/tasks/message/disposal.rs
+++ b/src/driver/tasks/message/disposal.rs
@@ -1,0 +1,9 @@
+#![allow(missing_docs)]
+
+use crate::tracks::Track;
+
+pub enum DisposalMessage {
+    Track(Track),
+
+    Poison,
+}

--- a/src/driver/tasks/message/mod.rs
+++ b/src/driver/tasks/message/mod.rs
@@ -1,13 +1,14 @@
 #![allow(missing_docs)]
 
 mod core;
+mod disposal;
 mod events;
 mod mixer;
 mod udp_rx;
 mod udp_tx;
 mod ws;
 
-pub use self::{core::*, events::*, mixer::*, udp_rx::*, udp_tx::*, ws::*};
+pub use self::{core::*, disposal::*, events::*, mixer::*, udp_rx::*, udp_tx::*, ws::*};
 
 use flume::Sender;
 use tracing::info;

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+pub(crate) mod disposal;
 pub mod error;
 mod events;
 pub mod message;


### PR DESCRIPTION
Linux/Unix requires that processes be `wait`ed, which is unfortunate as Windows lets us abandon them to the murderous whims of the OS. This PR adds Unix-specific behaviour to send a SIGINT before waiting on the process, and adds an additional thread per call for asset disposal on all platforms.

Closes #38.