### PR TITLE
Prevent mixer thread from waking while inactive

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -267,6 +267,9 @@ impl Songbird {
     /// associated voice channel, if connected.
     ///
     /// This will _not_ drop the handler, and will preserve it and its settings.
+    /// If you do not need to reuse event handlers, configuration, or active tracks
+    /// in the underlying driver *consider calling [`remove`]* to release tasks,
+    /// threads, and memory.
     ///
     /// This is a wrapper around [getting][`get`] a handler and calling
     /// [`leave`] on it.
@@ -274,6 +277,7 @@ impl Songbird {
     /// [`Call`]: Call
     /// [`get`]: Songbird::get
     /// [`leave`]: Call::leave
+    /// [`remove`]: Songbird::remove
     #[inline]
     pub async fn leave<G: Into<GuildId>>(&self, guild_id: G) -> JoinResult<()> {
         self._leave(guild_id.into()).await


### PR DESCRIPTION
This change prevents mixer threads from waking every 20ms without an active voice connection. This was leading to unacceptably high CPU usage in cases where users needed to preserve this state between many active connections. Additionally, this modifies the documentation of `Songbird::leave` to emphasise why users would prefer to `remove` their calls.

This was tested by examining the CPU usage in task manager before and after the change was made, using a control of 10k manually created `Driver` instances. After creation is finished, the Drivers no longer saturate a 6-core laptop Intel i7 (while they very much did so before).

Closes #42.