### PR TITLE
Gateway: Allow connection info to be retrieved

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -230,6 +230,16 @@ impl Call {
         self.update().await.map(|_| rx.into_recv_async())
     }
 
+    /// Returns the current voice connection details for this Call,
+    /// if available.
+    #[instrument(skip(self))]
+    pub fn current_connection(&self) -> Option<&ConnectionInfo> {
+        match &self.connection {
+            Some((_, progress, _)) => progress.get_connection_info(),
+            _ => None,
+        }
+    }
+
     /// Leaves the current voice channel, disconnecting from it.
     ///
     /// This does _not_ forget settings, like whether to be self-deafened or

--- a/src/info.rs
+++ b/src/info.rs
@@ -16,6 +16,14 @@ impl ConnectionProgress {
         })
     }
 
+    pub(crate) fn get_connection_info(&self) -> Option<&ConnectionInfo> {
+        use ConnectionProgress::*;
+        match self {
+            Complete(c) => Some(&c),
+            _ => None,
+        }
+    }
+
     pub(crate) fn apply_state_update(&mut self, session_id: String) -> bool {
         use ConnectionProgress::*;
         match self {


### PR DESCRIPTION
This is a simple addition to allow current connection state to be retrieved *after* establishment, even when using the voice driver.

This has been tested using `cargo make ready`, as it is fairly simple functionality.