### PR TITLE
Gateway: Add connection timeout, add `Config` to gateway.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,7 @@ If the driver feature is enabled, then every `Call` is/has an associated `Driver
 src/manager.rs
 src/handler.rs
 src/serenity.rs
+src/join.rs
 ```
 
 # Driver

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ version = "0.3"
 optional = true
 version = "0.11"
 
+[dependencies.pin-project]
+optional = true
+version = "1"
+
 [dependencies.rand]
 optional = true
 version = "0.8"
@@ -139,11 +143,13 @@ default = [
 gateway = [
     "gateway-core",
     "tokio/sync",
+    "tokio/time",
 ]
 gateway-core = [
     "dashmap",
     "flume",
     "parking_lot",
+    "pin-project",
 ]
 driver = [
     "async-tungstenite",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,18 +14,18 @@ command = "cargo"
 dependencies = ["format"]
 
 [tasks.build-gateway]
-args = ["build", "--features", "serenity-rustls"]
+args = ["build", "--no-default-features", "--features", "serenity-rustls"]
 command = "cargo"
 dependencies = ["format"]
 
 [tasks.build-driver]
-args = ["build", "--features", "driver,rustls"]
+args = ["build", "--no-default-features", "--features", "driver,rustls"]
 command = "cargo"
 dependencies = ["format"]
 
 [tasks.build-old-tokio]
 command = "cargo"
-args = ["build", "--features", "serenity-rustls-tokio-02,driver-tokio-02"]
+args = ["build", "--no-default-features", "--features", "serenity-rustls-tokio-02,driver-tokio-02"]
 dependencies = ["format"]
 
 [tasks.build-variants]
@@ -45,7 +45,12 @@ command = "cargo"
 args = ["bench", "--features", "internals,full-doc"]
 
 [tasks.doc]
+command = "cargo"
 args = ["doc", "--features", "full-doc"]
+
+[tasks.doc-open]
+command = "cargo"
+args = ["doc", "--features", "full-doc", "--open"]
 
 [tasks.ready]
 dependencies = ["format", "test", "build-variants", "build-examples", "doc", "clippy"]

--- a/examples/serenity/voice_receive/src/main.rs
+++ b/examples/serenity/voice_receive/src/main.rs
@@ -28,14 +28,14 @@ use serenity::{
 };
 
 use songbird::{
-    driver::{Config as DriverConfig, DecodeMode},
+    driver::DecodeMode,
     model::payload::{ClientConnect, ClientDisconnect, Speaking},
+    Config,
     CoreEvent,
     Event,
     EventContext,
     EventHandler as VoiceEventHandler,
     SerenityInit,
-    Songbird,
 };
 
 struct Handler;
@@ -167,16 +167,13 @@ async fn main() {
     // Here, we need to configure Songbird to decode all incoming voice packets.
     // If you want, you can do this on a per-call basis---here, we need it to
     // read the audio data that other people are sending us!
-    let songbird = Songbird::serenity();
-    songbird.set_config(
-        DriverConfig::default()
-            .decode_mode(DecodeMode::Decode)
-    );
+    let songbird_config = Config::default()
+        .decode_mode(DecodeMode::Decode);
 
     let mut client = Client::builder(&token)
         .event_handler(Handler)
         .framework(framework)
-        .register_songbird_with(songbird.into())
+        .register_songbird_from_config(songbird_config)
         .await
         .expect("Err creating client");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,9 +36,17 @@ pub struct Config {
     /// [user speaking events]: crate::events::CoreEvent::SpeakingUpdate
     pub decode_mode: DecodeMode,
     #[cfg(feature = "gateway-core")]
-    /// TODO
+    /// Configures the amount of time to wait for Discord to reply with connection information
+    /// if [`Call::join`]/[`join_gateway`] are used.
+    ///
+    /// This is a useful fallback in the event that:
+    ///  * the underlying Discord client restarts and loses a join request, or
+    ///  * a channel join fails because the bot is already believed to be there.
     ///
     /// Defaults to 10 seconds. If set to `None`, connections will never time out.
+    ///
+    /// [`Call::join`]: crate::Call::join
+    /// [`join_gateway`]: crate::Call::join_gateway
     pub gateway_timeout: Option<Duration>,
     #[cfg(feature = "driver-core")]
     /// Number of concurrently active tracks to allocate memory for.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,14 @@
-use super::{CryptoMode, DecodeMode};
+#[cfg(feature = "driver-core")]
+use super::driver::{CryptoMode, DecodeMode};
 
-/// Configuration for the inner Driver.
-///
+#[cfg(feature = "gateway-core")]
+use std::time::Duration;
+
+/// Configuration for drivers and calls.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Config {
+    #[cfg(feature = "driver-core")]
     /// Selected tagging mode for voice packet encryption.
     ///
     /// Defaults to [`CryptoMode::Normal`].
@@ -14,6 +19,7 @@ pub struct Config {
     ///
     /// [`CryptoMode::Normal`]: CryptoMode::Normal
     pub crypto_mode: CryptoMode,
+    #[cfg(feature = "driver-core")]
     /// Configures whether decoding and decryption occur for all received packets.
     ///
     /// If voice receiving voice packets, generally you should choose [`DecodeMode::Decode`].
@@ -29,6 +35,12 @@ pub struct Config {
     /// [`DecodeMode::Pass`]: DecodeMode::Pass
     /// [user speaking events]: crate::events::CoreEvent::SpeakingUpdate
     pub decode_mode: DecodeMode,
+    #[cfg(feature = "gateway-core")]
+    /// TODO
+    ///
+    /// Defaults to 10 seconds. If set to `None`, connections will never time out.
+    pub gateway_timeout: Option<Duration>,
+    #[cfg(feature = "driver-core")]
     /// Number of concurrently active tracks to allocate memory for.
     ///
     /// This should be set at, or just above, the maximum number of tracks
@@ -46,13 +58,19 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            #[cfg(feature = "driver-core")]
             crypto_mode: CryptoMode::Normal,
+            #[cfg(feature = "driver-core")]
             decode_mode: DecodeMode::Decrypt,
+            #[cfg(feature = "gateway-core")]
+            gateway_timeout: Some(Duration::from_secs(10)),
+            #[cfg(feature = "driver-core")]
             preallocated_tracks: 1,
         }
     }
 }
 
+#[cfg(feature = "driver-core")]
 impl Config {
     /// Sets this `Config`'s chosen cryptographic tagging scheme.
     pub fn crypto_mode(mut self, crypto_mode: CryptoMode) -> Self {
@@ -77,5 +95,14 @@ impl Config {
         if connected {
             self.crypto_mode = previous.crypto_mode;
         }
+    }
+}
+
+#[cfg(feature = "gateway-core")]
+impl Config {
+    /// Sets this `Config`'s timeout for joining a voice channel.
+    pub fn gateway_timeout(mut self, gateway_timeout: Option<Duration>) -> Self {
+        self.gateway_timeout = gateway_timeout;
+        self
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -11,13 +11,11 @@
 #[cfg(feature = "internals")]
 pub mod bench_internals;
 
-mod config;
 pub(crate) mod connection;
 mod crypto;
 mod decode_mode;
 pub(crate) mod tasks;
 
-pub use config::Config;
 use connection::error::{Error, Result};
 pub use crypto::CryptoMode;
 pub(crate) use crypto::CryptoState;
@@ -29,6 +27,7 @@ use crate::{
     events::EventData,
     input::Input,
     tracks::{self, Track, TrackHandle},
+    Config,
     ConnectionInfo,
     Event,
     EventHandler,
@@ -212,11 +211,17 @@ impl Driver {
         self.send(CoreMessage::SetTrack(None))
     }
 
-    /// Sets the configuration for this driver.
+    /// Sets the configuration for this driver (and parent `Call`, if applicable).
     #[instrument(skip(self))]
     pub fn set_config(&mut self, config: Config) {
         self.config = config.clone();
         self.send(CoreMessage::SetConfig(config))
+    }
+
+    /// Returns a view of this driver's configuration.
+    #[instrument(skip(self))]
+    pub fn config(&self) -> &Config {
+        &self.config
     }
 
     /// Attach a global event handler to an audio context. Global events may receive

--- a/src/driver/tasks/error.rs
+++ b/src/driver/tasks/error.rs
@@ -17,6 +17,7 @@ pub enum Recipient {
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     Crypto(CryptoError),
     /// Received an illegal voice packet on the voice UDP socket.

--- a/src/driver/tasks/mixer.rs
+++ b/src/driver/tasks/mixer.rs
@@ -1,7 +1,8 @@
-use super::{disposal, error::Result, message::*, Config};
+use super::{disposal, error::Result, message::*};
 use crate::{
     constants::*,
     tracks::{PlayMode, Track},
+    Config,
 };
 use audiopus::{
     coder::Encoder as OpusEncoder,

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -9,11 +9,8 @@ pub(crate) mod udp_rx;
 pub(crate) mod udp_tx;
 pub(crate) mod ws;
 
-use super::{
-    connection::{error::Error as ConnectionError, Connection},
-    Config,
-};
-use crate::events::CoreContext;
+use super::connection::{error::Error as ConnectionError, Connection};
+use crate::{events::CoreContext, Config};
 use flume::{Receiver, RecvError, Sender};
 use message::*;
 #[cfg(not(feature = "tokio-02-marker"))]

--- a/src/driver/tasks/udp_rx.rs
+++ b/src/driver/tasks/udp_rx.rs
@@ -1,12 +1,9 @@
 use super::{
     error::{Error, Result},
     message::*,
+    Config,
 };
-use crate::{
-    constants::*,
-    driver::{Config, DecodeMode},
-    events::CoreContext,
-};
+use crate::{constants::*, driver::DecodeMode, events::CoreContext};
 use audiopus::{
     coder::Decoder as OpusDecoder,
     error::{Error as OpusError, ErrorCode},

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,7 @@ pub enum JoinError {
     Twilight(CommandError),
 }
 
+#[cfg(feature = "gateway-core")]
 impl JoinError {
     /// Indicates whether this failure may have left (or been
     /// caused by) Discord's gateway state being in an
@@ -58,13 +59,19 @@ impl JoinError {
     /// Failure to `leave` before rejoining may cause further
     /// timeouts.
     pub fn should_leave_server(&self) -> bool {
-        use JoinError::*;
-        match self {
-            TimedOut => true,
-            #[cfg(feature = "driver-core")]
-            Driver(_) => true,
-            _ => false,
-        }
+        matches!(self, JoinError::TimedOut)
+    }
+
+    #[cfg(feature = "driver-core")]
+    /// Indicates whether this failure can be reattempted via
+    /// [`Driver::connect`] with retreived connection info.
+    ///
+    /// Failure to `leave` before rejoining may cause further
+    /// timeouts.
+    ///
+    /// [`Driver::connect`]: crate::driver::Driver
+    pub fn should_reconnect_driver(&self) -> bool {
+        matches!(self, JoinError::Driver(_))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use twilight_gateway::shard::CommandError;
 
 #[cfg(feature = "gateway-core")]
 #[derive(Debug)]
+#[non_exhaustive]
 /// Error returned when a manager or call handler is
 /// unable to send messages over Discord's gateway.
 pub enum JoinError {
@@ -23,8 +24,23 @@ pub enum JoinError {
     ///
     /// [`Call`]: crate::Call
     NoCall,
+    /// Connection details were not received from Discord in the
+    /// time given in [the `Call`'s configuration].
+    ///
+    /// This can occur if a message is lost by the Discord client
+    /// between restarts, or if Discord's gateway believes that
+    /// this bot is still in the channel it attempts to join.
+    ///
+    /// *Users should `leave` the server on the gateway before
+    /// re-attempting connection.*
+    ///
+    /// [the `Call`'s configuration]: crate::Config
+    TimedOut,
     #[cfg(feature = "driver-core")]
     /// The driver failed to establish a voice connection.
+    ///
+    /// *Users should `leave` the server on the gateway before
+    /// re-attempting connection.*
     Driver(ConnectionError),
     #[cfg(feature = "serenity")]
     /// Serenity-specific WebSocket send error.
@@ -32,6 +48,24 @@ pub enum JoinError {
     #[cfg(feature = "twilight")]
     /// Twilight-specific WebSocket send error.
     Twilight(CommandError),
+}
+
+impl JoinError {
+    /// Indicates whether this failure may have left (or been
+    /// caused by) Discord's gateway state being in an
+    /// inconsistent state.
+    ///
+    /// Failure to `leave` before rejoining may cause further
+    /// timeouts.
+    pub fn should_leave_server(&self) -> bool {
+        use JoinError::*;
+        match self {
+            TimedOut => true,
+            #[cfg(feature = "driver-core")]
+            Driver(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(feature = "gateway-core")]
@@ -42,6 +76,7 @@ impl fmt::Display for JoinError {
             JoinError::Dropped => write!(f, "request was cancelled/dropped."),
             JoinError::NoSender => write!(f, "no gateway destination."),
             JoinError::NoCall => write!(f, "tried to leave a non-existent call."),
+            JoinError::TimedOut => write!(f, "gateway response from Discord timed out."),
             #[cfg(feature = "driver-core")]
             JoinError::Driver(t) => write!(f, "internal driver error {}.", t),
             #[cfg(feature = "serenity")]

--- a/src/input/cached/tests.rs
+++ b/src/input/cached/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     constants::*,
-    input::{error::Error, ffmpeg, Codec, Container, Input, Reader},
+    input::{error::Error, Codec, Container, Input},
     test_utils::*,
 };
 use audiopus::{coder::Decoder, Bitrate, Channels, SampleRate};

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -559,7 +559,7 @@ mod tests {
         let mut input = Input::new(false, data.clone().into(), Codec::Pcm, Container::Raw, None);
 
         let mut out_vec = vec![];
-        let len = input.read_to_end(&mut out_vec).unwrap();
+        let _len = input.read_to_end(&mut out_vec).unwrap();
 
         let mut i16_window = &data[..];
         let mut float_window = &out_vec[..];
@@ -580,7 +580,7 @@ mod tests {
         let mut input = Input::new(true, data.clone().into(), Codec::Pcm, Container::Raw, None);
 
         let mut out_vec = vec![];
-        let len = input.read_to_end(&mut out_vec).unwrap();
+        let _len = input.read_to_end(&mut out_vec).unwrap();
 
         let mut i16_window = &data[..];
         let mut float_window = &out_vec[..];

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,0 +1,106 @@
+#[cfg(feature = "driver-core")]
+use crate::error::ConnectionResult;
+use crate::{
+    error::{JoinError, JoinResult},
+    ConnectionInfo,
+};
+use core::{
+    convert,
+    future::Future,
+    marker::Unpin,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use flume::r#async::RecvFut;
+use pin_project::pin_project;
+use tokio::time::{self, Timeout};
+
+#[cfg(feature = "driver-core")]
+/// TODO
+#[pin_project]
+pub struct Join {
+    #[pin]
+    inner: JoinClass<ConnectionResult<()>>,
+}
+
+#[cfg(feature = "driver-core")]
+impl Join {
+    pub(crate) fn new(
+        recv: RecvFut<'static, ConnectionResult<()>>,
+        timeout: Option<Duration>,
+    ) -> Self {
+        Self {
+            inner: JoinClass::new(recv, timeout),
+        }
+    }
+}
+
+#[cfg(feature = "driver-core")]
+impl Future for Join {
+    type Output = JoinResult<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project()
+            .inner
+            .poll(cx)
+            .map_ok(|inner_res| inner_res.map_err(JoinError::Driver))
+            .map(|m| m.and_then(convert::identity))
+    }
+}
+
+/// TODO
+#[pin_project]
+pub struct JoinGateway {
+    #[pin]
+    inner: JoinClass<ConnectionInfo>,
+}
+
+impl JoinGateway {
+    pub(crate) fn new(recv: RecvFut<'static, ConnectionInfo>, timeout: Option<Duration>) -> Self {
+        Self {
+            inner: JoinClass::new(recv, timeout),
+        }
+    }
+}
+
+impl Future for JoinGateway {
+    type Output = JoinResult<ConnectionInfo>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}
+
+#[pin_project(project = JoinClassProj)]
+enum JoinClass<T: 'static> {
+    WithTimeout(#[pin] Timeout<RecvFut<'static, T>>),
+    Vanilla(RecvFut<'static, T>),
+}
+
+impl<T: 'static> JoinClass<T> {
+    pub(crate) fn new(recv: RecvFut<'static, T>, timeout: Option<Duration>) -> Self {
+        match timeout {
+            Some(t) => JoinClass::WithTimeout(time::timeout(t, recv)),
+            None => JoinClass::Vanilla(recv),
+        }
+    }
+}
+
+impl<T> Future for JoinClass<T>
+where
+    T: Unpin,
+{
+    type Output = JoinResult<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            JoinClassProj::WithTimeout(t) => t
+                .poll(cx)
+                .map_err(|_| JoinError::TimedOut)
+                .map_ok(|res| res.map_err(|_| JoinError::Dropped))
+                .map(|m| m.and_then(convert::identity)),
+            JoinClassProj::Vanilla(t) => Pin::new(t).poll(cx).map_err(|_| JoinError::Dropped),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub(crate) mod info;
 #[cfg(feature = "driver-core")]
 pub mod input;
 #[cfg(feature = "gateway-core")]
-mod join;
+pub mod join;
 #[cfg(feature = "gateway-core")]
 mod manager;
 #[cfg(feature = "serenity")]
@@ -64,6 +64,7 @@ pub mod tracks;
 mod ws;
 
 #[cfg(feature = "driver-core")]
+/// Opus encoder bitrate settings.
 pub use audiopus::{self as opus, Bitrate};
 #[cfg(feature = "driver-core")]
 pub use discortp as packet;
@@ -84,7 +85,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "gateway-core")]
-pub use crate::{handler::*, join::*, manager::*};
+pub use crate::{handler::*, manager::*};
 
 #[cfg(feature = "serenity")]
 pub use crate::serenity::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! [`ConnectionInfo`]: struct@ConnectionInfo
 //! [lavalink]: https://github.com/Frederikam/Lavalink
 
+mod config;
 pub mod constants;
 #[cfg(feature = "driver-core")]
 pub mod driver;
@@ -49,6 +50,8 @@ pub mod id;
 pub(crate) mod info;
 #[cfg(feature = "driver-core")]
 pub mod input;
+#[cfg(feature = "gateway-core")]
+mod join;
 #[cfg(feature = "gateway-core")]
 mod manager;
 #[cfg(feature = "serenity")]
@@ -81,9 +84,10 @@ pub use crate::{
 };
 
 #[cfg(feature = "gateway-core")]
-pub use crate::{handler::*, manager::*};
+pub use crate::{handler::*, join::*, manager::*};
 
 #[cfg(feature = "serenity")]
 pub use crate::serenity::*;
 
+pub use config::Config;
 pub use info::ConnectionInfo;

--- a/src/serenity.rs
+++ b/src/serenity.rs
@@ -3,7 +3,7 @@
 //!
 //! [serenity]: https://crates.io/crates/serenity/0.9.0-rc.2
 
-use crate::manager::Songbird;
+use crate::{Config, Songbird};
 use serenity::{
     client::{ClientBuilder, Context},
     prelude::TypeMapKey,
@@ -37,6 +37,14 @@ pub fn register_with(client_builder: ClientBuilder, voice: Arc<Songbird>) -> Cli
         .type_map_insert::<SongbirdKey>(voice)
 }
 
+/// Installs a given songbird instance into the serenity client.
+///
+/// This should be called after any uses of `ClientBuilder::type_map`.
+pub fn register_from_config(client_builder: ClientBuilder, config: Config) -> ClientBuilder {
+    let voice = Songbird::serenity_from_config(config);
+    register_with(client_builder, voice)
+}
+
 /// Retrieve the Songbird voice client from a serenity context's
 /// shared key-value store.
 pub async fn get(ctx: &Context) -> Option<Arc<Songbird>> {
@@ -58,6 +66,8 @@ pub trait SerenityInit {
     fn register_songbird(self) -> Self;
     /// Registers a given Songbird voice system with serenity, as above.
     fn register_songbird_with(self, voice: Arc<Songbird>) -> Self;
+    /// Registers a Songbird voice system serenity, based on the given configuration.
+    fn register_songbird_from_config(self, config: Config) -> Self;
 }
 
 impl SerenityInit for ClientBuilder<'_> {
@@ -67,5 +77,9 @@ impl SerenityInit for ClientBuilder<'_> {
 
     fn register_songbird_with(self, voice: Arc<Songbird>) -> Self {
         register_with(self, voice)
+    }
+
+    fn register_songbird_from_config(self, config: Config) -> Self {
+        register_from_config(self, config)
     }
 }


### PR DESCRIPTION
This change fixes tasks hanging due to rare cases of messages being lost between full Discord reconnections by placing a configurable timeout on the `ConnectionInfo` responses. This is a companion fix to [serenity#1255](https://github.com/serenity-rs/serenity/pull/1255). To make this doable, `Config`s are now used by all versions of `Songbird`/`Call`, and relevant functions are  added to simplify setup with configuration. These are now non-exhaustive, correcting an earlier oversight. For future extensibility, this PR moves the return type of `join`/`join_gateway` into a custom future (no longer leaking flume's `RecvFut` type).

Additionally, this fixes the Makefile's feature sets for driver/gateway-only compilation.

This is a breaking change in:
* the return types of `join`/`join_gateway`
* moving `crate::driver::Config` -> `crate::Config`,
* `Config` and `JoinError` becoming `#[non_breaking]`.

This was tested via `cargo make ready`, and by testing `examples/serenity/voice_receive` with various timeout settings.