### PR TITLE
Deps: Bump DiscoRTP version -> 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "4"
 [dependencies.discortp]
 features = ["discord-full"]
 optional = true
-version = "0.2"
+version = "0.3"
 
 [dependencies.flume]
 optional = true


### PR DESCRIPTION
This change increases the version of DiscoRTP, which fixes upstream issues in libpnet and allows additional RTCP types to be added over time without breaking semver.

This is a breaking change for users explicitly matching on RTCP packet types, as DiscoRTP is exposed here.

This has been tested using `cargo make ready`.