### PR TITLE
Driver: Move `Bitrate` import out of crate root.

### DIFF
--- a/examples/serenity/voice_storage/src/main.rs
+++ b/examples/serenity/voice_storage/src/main.rs
@@ -27,12 +27,12 @@ use serenity::{
 };
 
 use songbird::{
+    driver::Bitrate,
     input::{
         self,
         cached::{Compressed, Memory},
         Input,
     },
-    Bitrate,
     Call,
     Event,
     EventContext,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -32,7 +32,8 @@ use crate::{
     Event,
     EventHandler,
 };
-use audiopus::Bitrate;
+/// Opus encoder bitrate settings.
+pub use audiopus::{self as opus, Bitrate};
 use core::{
     future::Future,
     pin::Pin,

--- a/src/driver/tasks/message/core.rs
+++ b/src/driver/tasks/message/core.rs
@@ -1,10 +1,9 @@
 #![allow(missing_docs)]
 
 use crate::{
-    driver::{connection::error::Error, Config},
+    driver::{connection::error::Error, Bitrate, Config},
     events::EventData,
     tracks::Track,
-    Bitrate,
     ConnectionInfo,
 };
 use flume::Sender;

--- a/src/driver/tasks/message/mixer.rs
+++ b/src/driver/tasks/message/mixer.rs
@@ -3,9 +3,8 @@
 use super::{Interconnect, UdpRxMessage, UdpTxMessage, WsMessage};
 
 use crate::{
-    driver::{Config, CryptoState},
+    driver::{Bitrate, Config, CryptoState},
     tracks::Track,
-    Bitrate,
 };
 use flume::Sender;
 use xsalsa20poly1305::XSalsa20Poly1305 as Cipher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,6 @@ pub mod tracks;
 mod ws;
 
 #[cfg(feature = "driver-core")]
-/// Opus encoder bitrate settings.
-pub use audiopus::{self as opus, Bitrate};
-#[cfg(feature = "driver-core")]
 pub use discortp as packet;
 #[cfg(feature = "driver-core")]
 pub use serenity_voice_model as model;


### PR DESCRIPTION
This is a simple organisational change which moves `crate::Bitrate` to `crate::driver::Bitrate` to slightly clean up the crate root.

This has been tested using `cargo make ready`.