### PR TITLE
Input: Rename YTDL error variants for Clippy

### DIFF
--- a/src/input/error.rs
+++ b/src/input/error.rs
@@ -35,13 +35,13 @@ pub enum Error {
     /// An error occurred while processing the JSON output from `youtube-dl`.
     ///
     /// The JSON output is given.
-    YouTubeDLProcessing(Value),
+    YouTubeDlProcessing(Value),
     /// An error occurred while running `youtube-dl`.
-    YouTubeDLRun(Output),
+    YouTubeDlRun(Output),
     /// The `url` field of the `youtube-dl` JSON output was not present.
     ///
     /// The JSON output is given.
-    YouTubeDLUrl(Value),
+    YouTubeDlUrl(Value),
 }
 
 impl From<CatcherError> for Error {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -247,7 +247,7 @@ impl Input {
                     }
 
                     // read from frame which is present.
-                    let mut buffer = &mut buffer[..];
+                    let mut buffer = buffer;
 
                     let start = decoder_state.frame_pos;
                     let to_write = float_space.min(decoder_state.current_frame.len() - start);
@@ -261,7 +261,7 @@ impl Input {
                 }
             },
             Codec::Pcm => {
-                let mut buffer = &mut buffer[..];
+                let mut buffer = buffer;
                 while written_floats < float_space {
                     if let Ok(signal) = self.reader.read_i16::<LittleEndian>() {
                         buffer.write_f32::<LittleEndian>(f32::from(signal) / 32768.0)?;


### PR DESCRIPTION
This silences a clippy lint around incorrect capitalisation of acronyms, but is a breaking API change.

This was tested using `cargo make ready`.