### PR TITLE
Introduce Call::current_channel

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -241,6 +241,10 @@ impl Call {
     }
 
     /// Returns `id` of the channel, if connected to any.
+    ///
+    /// **Note:**: Returned `id` is of the channel, to which bot performed connection.
+    /// It is possible that it is different from actual channel due to ability of server's admin to
+    /// move bot from channel to channel. This is to be fixed with next breaking change release.
     #[instrument(skip(self))]
     pub fn current_channel(&self) -> Option<ChannelId> {
         match &self.connection {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -240,6 +240,15 @@ impl Call {
         }
     }
 
+    /// Returns `id` of the channel, if connected to any.
+    #[instrument(skip(self))]
+    pub fn current_channel(&self) -> Option<ChannelId> {
+        match &self.connection {
+            Some((id, _, _)) => Some(*id),
+            _ => None,
+        }
+    }
+
     /// Leaves the current voice channel, disconnecting from it.
     ///
     /// This does _not_ forget settings, like whether to be self-deafened or


### PR DESCRIPTION
I'm not sure how you want to organize connection info and whether channel id should be separate from it.

For now I left it separated, just getting API to access it for user so that I could know whether I need to join new one or not

Fixes #58