### PR TITLE
Driver: Fix crash on `.leave()`

### DIFF
--- a/src/driver/tasks/mixer.rs
+++ b/src/driver/tasks/mixer.rs
@@ -132,11 +132,14 @@ impl Mixer {
                     };
                 }
 
-                if let Err(e) = self.cycle().and_then(|_| self.audio_commands_events()) {
-                    events_failure |= e.should_trigger_interconnect_rebuild();
-                    conn_failure |= e.should_trigger_connect();
+                // The above action may have invalidated the connection; need to re-check!
+                if self.conn_active.is_some() {
+                    if let Err(e) = self.cycle().and_then(|_| self.audio_commands_events()) {
+                        events_failure |= e.should_trigger_interconnect_rebuild();
+                        conn_failure |= e.should_trigger_connect();
 
-                    debug!("Mixer thread cycle: {:?}", e);
+                        debug!("Mixer thread cycle: {:?}", e);
+                    }
                 }
             } else {
                 match self.mix_rx.recv() {


### PR DESCRIPTION
Leaving (rather than removing) a call would cause the driver to crash as it would try to use a non-existent connection immediately after it had been invalidated.

This has been tested using a modified `examples/serenity/voice_storage`, felyne, and via `cargo make ready`.

Closes #56.