### PR TITLE
Deps: Prevent MSRV breakage via `spinning_top`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,11 @@ version = "0.1"
 optional = true
 version = "1"
 
+# TEMPORARY: remove on next breaking.
+[dependencies.spinning_top]
+optional = true
+version = "=0.2.2"
+
 [dependencies.streamcatcher]
 optional = true
 version = "0.1"
@@ -142,6 +147,7 @@ gateway-core = [
     "dashmap",
     "flume",
     "parking_lot",
+    "spinning_top",
 ]
 driver = [
     "async-tungstenite",
@@ -165,6 +171,7 @@ driver-core = [
     "rand",
     "serenity-voice-model",
     "spin_sleep",
+    "spinning_top",
     "streamcatcher",
     "typemap_rev",
     "url",


### PR DESCRIPTION
The upstream crate `spinning_top` used newer elements of rustc's std in a patch release, unknowingly bumping its MSRV to 1.49.0. This patch reverts to the older, compatible, version.

This has been tested by manually building `examples/serenity/voice` using rustc v1.48.0.

Closes #62.