### PR TITLE
Various: Make error messages more idiomatic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ features = ["v4"]
 [dependencies.xsalsa20poly1305]
 optional = true
 version = "0.7"
+features = ["std"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/input/error.rs
+++ b/src/input/error.rs
@@ -72,20 +72,20 @@ impl From<OpusError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Dca(e) => write!(f, "{}", e),
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Dca(_) => write!(f, "opening file DCA failed"),
+            Error::Io(e) => e.fmt(f),
             Error::Json {
-                error,
+                error: _,
                 parsed_text: _,
-            } => write!(f, "{}", error),
-            Error::Opus(e) => write!(f, "{}", e),
-            Error::Metadata => write!(f, "Failed to extract metadata"),
-            Error::Stdout => write!(f, "Failed to create stdout"),
-            Error::Streams => write!(f, "Error while checking if path is stereo"),
-            Error::Streamcatcher(e) => write!(f, "{}", e),
-            Error::YouTubeDlProcessing(_) => write!(f, "Processing JSON from youtube-dl failed"),
-            Error::YouTubeDlRun(_) => write!(f, "youtube-dl encountered an error"),
-            Error::YouTubeDlUrl(_) => write!(f, "Missing url field in JSON"),
+            } => write!(f, "parsing JSON failed"),
+            Error::Opus(e) => e.fmt(f),
+            Error::Metadata => write!(f, "extracting metadata failed"),
+            Error::Stdout => write!(f, "creating stdout failed"),
+            Error::Streams => write!(f, "checking if path is stereo failed"),
+            Error::Streamcatcher(_) => write!(f, "invalid config for cached input"),
+            Error::YouTubeDlProcessing(_) => write!(f, "youtube-dl returned invalid JSON"),
+            Error::YouTubeDlRun(o) => write!(f, "youtube-dl encontered an error: {:?}", o),
+            Error::YouTubeDlUrl(_) => write!(f, "missing youtube-dl url"),
         }
     }
 }
@@ -94,12 +94,12 @@ impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Error::Dca(e) => Some(e),
-            Error::Io(e) => Some(e),
+            Error::Io(e) => e.source(),
             Error::Json {
                 error,
                 parsed_text: _,
             } => Some(error),
-            Error::Opus(e) => Some(e),
+            Error::Opus(e) => e.source(),
             Error::Metadata => None,
             Error::Stdout => None,
             Error::Streams => None,
@@ -132,11 +132,11 @@ pub enum DcaError {
 impl fmt::Display for DcaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DcaError::IoError(e) => write!(f, "{}", e),
-            DcaError::InvalidHeader => write!(f, "Invalid DCA JSON header"),
-            DcaError::InvalidMetadata(e) => write!(f, "{}", e),
-            DcaError::InvalidSize(e) => write!(f, "Invalid metadata block size: {}", e),
-            DcaError::Opus(e) => write!(f, "{}", e),
+            DcaError::IoError(e) => e.fmt(f),
+            DcaError::InvalidHeader => write!(f, "invalid header"),
+            DcaError::InvalidMetadata(_) => write!(f, "invalid metadata"),
+            DcaError::InvalidSize(e) => write!(f, "invalid metadata block size: {}", e),
+            DcaError::Opus(e) => e.fmt(f),
         }
     }
 }
@@ -144,11 +144,11 @@ impl fmt::Display for DcaError {
 impl StdError for DcaError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            DcaError::IoError(e) => Some(e),
+            DcaError::IoError(e) => e.source(),
             DcaError::InvalidHeader => None,
             DcaError::InvalidMetadata(e) => Some(e),
             DcaError::InvalidSize(_) => None,
-            DcaError::Opus(e) => Some(e),
+            DcaError::Opus(e) => e.source(),
         }
     }
 }

--- a/src/tracks/error.rs
+++ b/src/tracks/error.rs
@@ -21,12 +21,12 @@ pub enum TrackError {
 
 impl fmt::Display for TrackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Failed to operate on track (handle): ")?;
+        write!(f, "failed to operate on track (handle): ")?;
         match self {
-            TrackError::Finished => write!(f, "track ended."),
+            TrackError::Finished => write!(f, "track ended"),
             TrackError::InvalidTrackEvent =>
-                write!(f, "given event listener can't be fired on a track."),
-            TrackError::SeekUnsupported => write!(f, "track did not support seeking."),
+                write!(f, "given event listener can't be fired on a track"),
+            TrackError::SeekUnsupported => write!(f, "track did not support seeking"),
         }
     }
 }


### PR DESCRIPTION
I recently read the `std::error::Error` [trait documentation](https://doc.rust-lang.org/nightly/std/error/trait.Error.html) and found that messages should (in general) be lowercase. After more searching I also found [this](https://users.rust-lang.org/t/do-people-not-care-about-printable-error-chains-a-k-a-how-to-nicely-implement-display-for-an-error/35362) which talks about how `std::error::Error::source` should behave (to produce nice error chains).

This pull requests implements these lessons for *most* error types (I didn't want to touch some of `songbird::error::ConnectionError`'s errors (like `songbird::ws::Error`) due to their complexity).

Tested with `cargo make ready`