### PR TITLE
Input: Add separate YouTube title and channel to Metadata

### DIFF
--- a/examples/twilight/src/main.rs
+++ b/examples/twilight/src/main.rs
@@ -190,7 +190,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
             "Playing **{:?}** by **{:?}**",
             input
                 .metadata
-                .title
+                .track
                 .as_ref()
                 .unwrap_or(&"<UNKNOWN>".to_string()),
             input

--- a/src/input/dca.rs
+++ b/src/input/dca.rs
@@ -118,7 +118,7 @@ pub(crate) struct Origin {
 
 impl From<DcaMetadata> for Metadata {
     fn from(mut d: DcaMetadata) -> Self {
-        let (title, artist) = d
+        let (track, artist) = d
             .info
             .take()
             .map(|mut m| (m.title.take(), m.artist.take()))
@@ -128,7 +128,7 @@ impl From<DcaMetadata> for Metadata {
         let sample_rate = Some(d.opus.sample_rate);
 
         Self {
-            title,
+            track,
             artist,
 
             channels,

--- a/src/input/metadata.rs
+++ b/src/input/metadata.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 /// [`Input`]: crate::input::Input
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Metadata {
-    /// The title of this stream.
-    pub title: Option<String>,
+    /// The track of this stream.
+    pub track: Option<String>,
     /// The main artist of this stream.
     pub artist: Option<String>,
     /// The date of creation of this stream.
@@ -18,6 +18,8 @@ pub struct Metadata {
     ///
     /// Any number `>= 2` is treated as stereo.
     pub channels: Option<u8>,
+    /// The YouTube channel of this stream.
+    pub channel: Option<String>,
     /// The time at which the first true sample is played back.
     ///
     /// This occurs as an artefact of coder delay.
@@ -28,6 +30,8 @@ pub struct Metadata {
     pub sample_rate: Option<u32>,
     /// The source url of this stream.
     pub source_url: Option<String>,
+    /// The YouTube title of this stream.
+    pub title: Option<String>,
     /// The thumbnail url of this stream.
     pub thumbnail: Option<String>,
 }
@@ -52,7 +56,7 @@ impl Metadata {
 
         let tags = format.and_then(|m| m.get("tags"));
 
-        let title = tags
+        let track = tags
             .and_then(|m| m.get("title"))
             .and_then(Value::as_str)
             .map(str::to_string);
@@ -88,7 +92,7 @@ impl Metadata {
             .map(|v| v as u32);
 
         Self {
-            title,
+            track,
             artist,
             date,
 
@@ -109,12 +113,6 @@ impl Metadata {
             .and_then(|m| m.get("track"))
             .and_then(Value::as_str)
             .map(str::to_string);
-
-        let title = track.or_else(|| {
-            obj.and_then(|m| m.get("title"))
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        });
 
         let true_artist = obj
             .and_then(|m| m.get("artist"))
@@ -138,6 +136,11 @@ impl Metadata {
                 .map(str::to_string)
         });
 
+        let channel = obj
+            .and_then(|m| m.get("channel"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
         let duration = obj
             .and_then(|m| m.get("duration"))
             .and_then(Value::as_f64)
@@ -148,20 +151,27 @@ impl Metadata {
             .and_then(Value::as_str)
             .map(str::to_string);
 
+        let title = obj
+            .and_then(|m| m.get("title"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
         let thumbnail = obj
             .and_then(|m| m.get("thumbnail"))
             .and_then(Value::as_str)
             .map(str::to_string);
 
         Self {
-            title,
+            track,
             artist,
             date,
 
             channels: Some(2),
+            channel,
             duration,
             sample_rate: Some(SAMPLE_RATE_RAW as u32),
             source_url,
+            title,
             thumbnail,
 
             ..Default::default()
@@ -171,15 +181,17 @@ impl Metadata {
     /// Move all fields from a `Metadata` object into a new one.
     pub fn take(&mut self) -> Self {
         Self {
-            title: self.title.take(),
+            track: self.track.take(),
             artist: self.artist.take(),
             date: self.date.take(),
 
             channels: self.channels.take(),
+            channel: self.channel.take(),
             start_time: self.start_time.take(),
             duration: self.duration.take(),
             sample_rate: self.sample_rate.take(),
             source_url: self.source_url.take(),
+            title: self.title.take(),
             thumbnail: self.thumbnail.take(),
         }
     }


### PR DESCRIPTION
Adds YouTube channel since it's often provided when talking about YouTube content (Rythm includes it when enqueueing a track ([picture](https://user-images.githubusercontent.com/26655508/119718617-113cb700-be68-11eb-85b8-69069580ee37.png))).

Tested with `cargo make ready` and in my own bot

In the future I'd like for there to also be support for who enqueued a track, but I think this info should maybe not be in metadata (since it should probably only contain information about the track).