### PR TITLE
Driver: Automate (re)connection logic

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,12 @@ impl Config {
         self
     }
 
+    /// Sets this `Config`'s voice connection retry configuration.
+    pub fn driver_retry(mut self, driver_retry: Retry) -> Self {
+        self.driver_retry = driver_retry;
+        self
+    }
+
     /// This is used to prevent changes which would invalidate the current session.
     pub(crate) fn make_safe(&mut self, previous: &Config, connected: bool) {
         if connected {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "driver-core")]
-use super::driver::{CryptoMode, DecodeMode};
+use super::driver::{retry::Retry, CryptoMode, DecodeMode};
 
-#[cfg(feature = "gateway-core")]
 use std::time::Duration;
 
 /// Configuration for drivers and calls.
@@ -61,6 +60,20 @@ pub struct Config {
     /// Changes to this field in a running driver will only ever increase
     /// the capacity of the track store.
     pub preallocated_tracks: usize,
+    #[cfg(feature = "driver-core")]
+    /// Connection retry logic for the [`Driver`].
+    ///
+    /// This controls how many times the [`Driver`] should retry any connections,
+    /// as well as how long to wait between attempts.
+    ///
+    /// [`Driver`]: crate::driver::Driver
+    pub driver_retry: Retry,
+    #[cfg(feature = "driver-core")]
+    /// Configures the maximum amount of time to wait for an attempted voice
+    /// connection to Discord.
+    ///
+    /// Defaults to 10 seconds. If set to `None`, connections will never time out.
+    pub driver_timeout: Option<Duration>,
 }
 
 impl Default for Config {
@@ -74,6 +87,10 @@ impl Default for Config {
             gateway_timeout: Some(Duration::from_secs(10)),
             #[cfg(feature = "driver-core")]
             preallocated_tracks: 1,
+            #[cfg(feature = "driver-core")]
+            driver_retry: Default::default(),
+            #[cfg(feature = "driver-core")]
+            driver_timeout: Some(Duration::from_secs(10)),
         }
     }
 }
@@ -95,6 +112,12 @@ impl Config {
     /// Sets this `Config`'s number of tracks to preallocate.
     pub fn preallocated_tracks(mut self, preallocated_tracks: usize) -> Self {
         self.preallocated_tracks = preallocated_tracks;
+        self
+    }
+
+    /// Sets this `Config`'s timeout for establishing a voice connection.
+    pub fn driver_timeout(mut self, driver_timeout: Option<Duration>) -> Self {
+        self.driver_timeout = driver_timeout;
         self
     }
 

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -45,11 +45,12 @@ impl Connection {
         info: ConnectionInfo,
         interconnect: &Interconnect,
         config: &Config,
+        idx: usize,
     ) -> Result<Connection> {
         if let Some(t) = config.driver_timeout {
-            timeout(t, Connection::new_inner(info, interconnect, config)).await?
+            timeout(t, Connection::new_inner(info, interconnect, config, idx)).await?
         } else {
-            Connection::new_inner(info, interconnect, config).await
+            Connection::new_inner(info, interconnect, config, idx).await
         }
     }
 
@@ -57,6 +58,7 @@ impl Connection {
         mut info: ConnectionInfo,
         interconnect: &Interconnect,
         config: &Config,
+        idx: usize,
     ) -> Result<Connection> {
         let url = generate_url(&mut info.endpoint)?;
 
@@ -219,6 +221,8 @@ impl Connection {
             client,
             ssrc,
             hello.heartbeat_interval,
+            idx,
+            info.clone(),
         ));
 
         spawn(udp_rx::runner(

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -14,6 +14,7 @@ pub mod bench_internals;
 pub(crate) mod connection;
 mod crypto;
 mod decode_mode;
+pub mod retry;
 pub(crate) mod tasks;
 
 use connection::error::{Error, Result};

--- a/src/driver/retry/mod.rs
+++ b/src/driver/retry/mod.rs
@@ -1,0 +1,33 @@
+//! Configuration for connection retries.
+
+mod strategy;
+
+pub use self::strategy::*;
+
+/// Configuration to be used for retrying driver connection attempts.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Retry {
+    /// Strategy used to determine how long to wait between retry attempts.
+    ///
+    /// *Defaults to an [`ExponentialBackoff`] from 0.25s
+    /// to 10s, with a jitter of `0.1`.*
+    ///
+    /// [`ExponentialBackoff`]: Strategy::Backoff
+    pub strategy: Strategy,
+    /// The maximum number of retries to attempt.
+    ///
+    /// `None` will attempt an infinite number of retries,
+    /// while `Some(0)` will attempt to connect *once* (no retries).
+    ///
+    /// *Defaults to `Some(5)`.*
+    pub retry_limit: Option<usize>,
+}
+
+impl Default for Retry {
+    fn default() -> Self {
+        Self {
+            strategy: Strategy::Backoff(Default::default()),
+            retry_limit: Some(5),
+        }
+    }
+}

--- a/src/driver/retry/mod.rs
+++ b/src/driver/retry/mod.rs
@@ -4,6 +4,8 @@ mod strategy;
 
 pub use self::strategy::*;
 
+use std::time::Duration;
+
 /// Configuration to be used for retrying driver connection attempts.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Retry {
@@ -28,6 +30,20 @@ impl Default for Retry {
         Self {
             strategy: Strategy::Backoff(Default::default()),
             retry_limit: Some(5),
+        }
+    }
+}
+
+impl Retry {
+    pub(crate) fn retry_in(
+        &self,
+        last_wait: Option<Duration>,
+        attempts: usize,
+    ) -> Option<Duration> {
+        if self.retry_limit.map(|a| attempts < a).unwrap_or(true) {
+            Some(self.strategy.retry_in(last_wait))
+        } else {
+            None
         }
     }
 }

--- a/src/driver/retry/strategy.rs
+++ b/src/driver/retry/strategy.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+/// Logic used to determine how long to wait between retry attempts.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Strategy {
+    /// The driver will wait for the same amount of time between each retry.
+    Every(Duration),
+    /// Exponential backoff waiting strategy, where the duration between
+    /// attempts (approximately) doubles each time.
+    Backoff(ExponentialBackoff),
+}
+
+/// Exponential backoff waiting strategy.
+///
+/// Each attempt waits for twice the last delay plus/minus a
+/// random jitter, clamped to a min and max value.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExponentialBackoff {
+    /// Minimum amount of time to wait between retries.
+    ///
+    /// *Defaults to 0.25s.*
+    pub min: Duration,
+    /// Maximum amount of time to wait between retries.
+    ///
+    /// This will be clamped to `>=` min.
+    ///
+    /// *Defaults to 10s.*
+    pub max: Duration,
+    /// Amount of uniform random jitter to apply to generated wait times.
+    /// I.e., 0.1 will add +/-10% to generated intervals.
+    ///
+    /// *Defaults to `0.1`.*
+    pub jitter: f32,
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self {
+            min: Duration::from_millis(250),
+            max: Duration::from_secs(10),
+            jitter: 0.1,
+        }
+    }
+}

--- a/src/driver/retry/strategy.rs
+++ b/src/driver/retry/strategy.rs
@@ -1,3 +1,4 @@
+use rand::random;
 use std::time::Duration;
 
 /// Logic used to determine how long to wait between retry attempts.
@@ -9,6 +10,15 @@ pub enum Strategy {
     /// Exponential backoff waiting strategy, where the duration between
     /// attempts (approximately) doubles each time.
     Backoff(ExponentialBackoff),
+}
+
+impl Strategy {
+    pub(crate) fn retry_in(&self, last_wait: Option<Duration>) -> Duration {
+        match self {
+            Self::Every(t) => *t,
+            Self::Backoff(exp) => exp.retry_in(last_wait),
+        }
+    }
 }
 
 /// Exponential backoff waiting strategy.
@@ -30,6 +40,8 @@ pub struct ExponentialBackoff {
     /// Amount of uniform random jitter to apply to generated wait times.
     /// I.e., 0.1 will add +/-10% to generated intervals.
     ///
+    /// This is restricted to within +/-100%.
+    ///
     /// *Defaults to `0.1`.*
     pub jitter: f32,
 }
@@ -41,5 +53,32 @@ impl Default for ExponentialBackoff {
             max: Duration::from_secs(10),
             jitter: 0.1,
         }
+    }
+}
+
+impl ExponentialBackoff {
+    pub(crate) fn retry_in(&self, last_wait: Option<Duration>) -> Duration {
+        let attempt = last_wait.map(|t| 2 * t).unwrap_or(self.min);
+        let perturb = (1.0 - (self.jitter * 2.0 * (random::<f32>() - 1.0)))
+            .max(0.0)
+            .min(2.0);
+        let mut target_time = attempt.mul_f32(perturb);
+
+        // Now clamp target time into given range.
+        let safe_max = if self.max < self.min {
+            self.min
+        } else {
+            self.max
+        };
+
+        if target_time > safe_max {
+            target_time = safe_max;
+        }
+
+        if target_time < self.min {
+            target_time = self.min;
+        }
+
+        target_time
     }
 }

--- a/src/driver/tasks/message/core.rs
+++ b/src/driver/tasks/message/core.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     driver::{connection::error::Error, Bitrate, Config},
-    events::EventData,
+    events::{context_data::DisconnectReason, EventData},
     tracks::Track,
     ConnectionInfo,
 };
@@ -13,6 +13,7 @@ use flume::Sender;
 pub enum CoreMessage {
     ConnectWithResult(ConnectionInfo, Sender<Result<(), Error>>),
     RetryConnect(usize),
+    SignalWsClosure(usize, ConnectionInfo, Option<DisconnectReason>),
     Disconnect,
     SetTrack(Option<Track>),
     AddTrack(Track),

--- a/src/driver/tasks/message/core.rs
+++ b/src/driver/tasks/message/core.rs
@@ -12,6 +12,7 @@ use flume::Sender;
 #[derive(Debug)]
 pub enum CoreMessage {
     ConnectWithResult(ConnectionInfo, Sender<Result<(), Error>>),
+    RetryConnect(usize),
     Disconnect,
     SetTrack(Option<Track>),
     AddTrack(Track),

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -97,7 +97,8 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
                             .attempt(&mut retrying, &interconnect, &config)
                             .await;
                     }
-                }},
+                }
+            },
             Ok(CoreMessage::Disconnect) => {
                 let last_conn = connection.take();
                 let _ = interconnect.mixer.send(MixerMessage::DropConn);
@@ -298,7 +299,13 @@ impl ConnectionRetryData {
                     self.attempts += 1;
                     self.last_wait = Some(t);
 
-                    debug!("Retrying connection for {:?} in {}s ({}/{:?})", self.info.guild_id, t.as_secs_f32(), self.attempts, config.driver_retry.retry_limit);
+                    debug!(
+                        "Retrying connection for {:?} in {}s ({}/{:?})",
+                        self.info.guild_id,
+                        t.as_secs_f32(),
+                        self.attempts,
+                        config.driver_retry.retry_limit
+                    );
 
                     *attempt_slot = Some(self);
                 } else {

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -138,7 +138,7 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
                     // if still issue, full connect.
                     let info = conn.info.clone();
 
-                    let full_connect = match conn.reconnect().await {
+                    let full_connect = match conn.reconnect(&config).await {
                         Ok(()) => {
                             connection = Some(conn);
                             false
@@ -146,7 +146,7 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
                         Err(ConnectionError::InterconnectFailure(_)) => {
                             interconnect.restart_volatile_internals();
 
-                            match conn.reconnect().await {
+                            match conn.reconnect(&config).await {
                                 Ok(()) => {
                                     connection = Some(conn);
                                     false

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -9,18 +9,21 @@ pub(crate) mod udp_rx;
 pub(crate) mod udp_tx;
 pub(crate) mod ws;
 
+use std::time::Duration;
+
 use super::connection::{error::Error as ConnectionError, Connection};
 use crate::{
     events::{internal_data::InternalConnect, CoreContext},
     Config,
+    ConnectionInfo,
 };
 use flume::{Receiver, RecvError, Sender};
 use message::*;
 #[cfg(not(feature = "tokio-02-marker"))]
-use tokio::{runtime::Handle, spawn};
+use tokio::{runtime::Handle, spawn, time::sleep as tsleep};
 #[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{runtime::Handle, spawn};
-use tracing::{error, instrument, trace};
+use tokio_compat::{runtime::Handle, spawn, time::delay as tsleep};
+use tracing::{instrument, trace};
 
 pub(crate) fn start(config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMessage>) {
     spawn(async move {
@@ -63,6 +66,8 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
     let mut next_config: Option<Config> = None;
     let mut connection = None;
     let mut interconnect = start_internals(tx, config.clone());
+    let mut retrying = None;
+    let mut attempt_idx = 0;
 
     loop {
         match rx.recv_async().await {
@@ -76,32 +81,18 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
                     config
                 };
 
-                connection = match Connection::new(info, &interconnect, &config).await {
-                    Ok(connection) => {
-                        // Other side may not be listening: this is fine.
-                        let _ = tx.send(Ok(()));
-
-                        let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                            CoreContext::DriverConnect(InternalConnect {
-                                server: connection.info.endpoint.clone(),
-                                ssrc: connection.ssrc,
-                            }),
-                        ));
-
-                        Some(connection)
-                    },
-                    Err(why) => {
-                        // See above.
-                        let _ = tx.send(Err(why));
-
-                        let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                            CoreContext::DriverConnectFailed,
-                        ));
-
-                        None
-                    },
-                };
+                connection = ConnectionRetryData::connect(tx, info, &mut attempt_idx)
+                    .attempt(&mut retrying, &interconnect, &config)
+                    .await;
             },
+            Ok(CoreMessage::RetryConnect(retry_idx)) =>
+                if retry_idx == attempt_idx {
+                    if let Some(progress) = retrying.take() {
+                        connection = progress
+                            .attempt(&mut retrying, &interconnect, &config)
+                            .await;
+                    }
+                },
             Ok(CoreMessage::Disconnect) => {
                 connection = None;
                 let _ = interconnect.mixer.send(MixerMessage::DropConn);
@@ -158,22 +149,13 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
                     };
 
                     if full_connect {
-                        connection = Connection::new(info, &interconnect, &config)
-                            .await
-                            .map_err(|e| {
-                                error!("Catastrophic connection failure. Stopping. {:?}", e);
-                                let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                                    CoreContext::DriverReconnectFailed,
-                                ));
-                                e
-                            })
-                            .ok();
-                    }
-
-                    if let Some(ref connection) = &connection {
+                        connection = ConnectionRetryData::reconnect(info, &mut attempt_idx)
+                            .attempt(&mut retrying, &interconnect, &config)
+                            .await;
+                    } else if let Some(ref connection) = &connection {
                         let _ = interconnect.events.send(EventMessage::FireCoreEvent(
                             CoreContext::DriverReconnect(InternalConnect {
-                                server: connection.info.endpoint.clone(),
+                                info: connection.info.clone(),
                                 ssrc: connection.ssrc,
                             }),
                         ));
@@ -184,25 +166,9 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
                 if let Some(conn) = connection.take() {
                     let info = conn.info.clone();
 
-                    connection = Connection::new(info, &interconnect, &config)
-                        .await
-                        .map_err(|e| {
-                            error!("Catastrophic connection failure. Stopping. {:?}", e);
-                            let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                                CoreContext::DriverReconnectFailed,
-                            ));
-                            e
-                        })
-                        .ok();
-
-                    if let Some(ref connection) = &connection {
-                        let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                            CoreContext::DriverReconnect(InternalConnect {
-                                server: connection.info.endpoint.clone(),
-                                ssrc: connection.ssrc,
-                            }),
-                        ));
-                    }
+                    connection = ConnectionRetryData::reconnect(info, &mut attempt_idx)
+                        .attempt(&mut retrying, &interconnect, &config)
+                        .await;
                 },
             Ok(CoreMessage::RebuildInterconnect) => {
                 interconnect.restart_volatile_internals();
@@ -215,4 +181,107 @@ async fn runner(mut config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMe
 
     trace!("Main thread exited");
     interconnect.poison_all();
+}
+
+struct ConnectionRetryData {
+    flavour: ConnectionFlavour,
+    attempts: usize,
+    last_wait: Option<Duration>,
+    info: ConnectionInfo,
+    idx: usize,
+}
+
+impl ConnectionRetryData {
+    fn connect(tx: Sender<Result<(), ConnectionError>>, info: ConnectionInfo, idx_src: &mut usize) -> Self {
+        Self::base(ConnectionFlavour::Connect(tx), info, idx_src)
+    }
+
+    fn reconnect(info: ConnectionInfo, idx_src: &mut usize) -> Self {
+        Self::base(ConnectionFlavour::Reconnect, info, idx_src)
+    }
+
+    fn base(flavour: ConnectionFlavour, info: ConnectionInfo, idx_src: &mut usize) -> Self {
+        let idx = *idx_src;
+        *idx_src = idx_src.wrapping_add(1);
+
+        Self {
+            flavour,
+            attempts: 0,
+            last_wait: None,
+            info,
+            idx,
+        }
+    }
+
+    async fn attempt(
+        mut self,
+        attempt_slot: &mut Option<Self>,
+        interconnect: &Interconnect,
+        config: &Config,
+    ) -> Option<Connection> {
+        match Connection::new(self.info.clone(), interconnect, config).await {
+            Ok(connection) => {
+                match self.flavour {
+                    ConnectionFlavour::Connect(tx) => {
+                        // Other side may not be listening: this is fine.
+                        let _ = tx.send(Ok(()));
+
+                        let _ = interconnect.events.send(EventMessage::FireCoreEvent(
+                            CoreContext::DriverConnect(InternalConnect {
+                                info: connection.info.clone(),
+                                ssrc: connection.ssrc,
+                            }),
+                        ));
+                    },
+                    ConnectionFlavour::Reconnect => {
+                        let _ = interconnect.events.send(EventMessage::FireCoreEvent(
+                            CoreContext::DriverReconnect(InternalConnect {
+                                info: connection.info.clone(),
+                                ssrc: connection.ssrc,
+                            }),
+                        ));
+                    },
+                }
+
+                Some(connection)
+            },
+            Err(why) => {
+                if let Some(t) = config.driver_retry.retry_in(self.last_wait, self.attempts) {
+                    let remote_ic = interconnect.clone();
+                    let idx = self.idx;
+                    spawn(async move {
+                        tsleep(t).await;
+                        let _ = remote_ic.core.send(CoreMessage::RetryConnect(idx));
+                    });
+
+                    self.attempts += 1;
+                    self.last_wait = Some(t);
+                    *attempt_slot = Some(self);
+                } else {
+                    match self.flavour {
+                        ConnectionFlavour::Connect(tx) => {
+                            // See above.
+                            let _ = tx.send(Err(why));
+
+                            let _ = interconnect.events.send(EventMessage::FireCoreEvent(
+                                CoreContext::DriverConnectFailed,
+                            ));
+                        },
+                        ConnectionFlavour::Reconnect => {
+                            let _ = interconnect.events.send(EventMessage::FireCoreEvent(
+                                CoreContext::DriverReconnectFailed,
+                            ));
+                        },
+                    }
+                }
+
+                None
+            },
+        }
+    }
+}
+
+enum ConnectionFlavour {
+    Connect(Sender<Result<(), ConnectionError>>),
+    Reconnect,
 }

--- a/src/events/context/data/connect.rs
+++ b/src/events/context/data/connect.rs
@@ -1,7 +1,18 @@
+use crate::id::*;
+
 /// Voice connection details gathered at setup/reinstantiation.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub struct ConnectData<'a> {
+    /// ID of the voice channel being joined, if it is known.
+    ///
+    /// If this is available, then this can be used to reconnect/renew
+    /// a voice session via thew gateway.
+    pub channel_id: Option<ChannelId>,
+    /// ID of the target voice channel's parent guild.
+    pub guild_id: GuildId,
+    /// Unique string describing this session for validation/authentication purposes.
+    pub session_id: &'a str,
     /// The domain name of Discord's voice/TURN server.
     ///
     /// With the introduction of Discord's automatic voice server selection,

--- a/src/events/context/data/disconnect.rs
+++ b/src/events/context/data/disconnect.rs
@@ -100,14 +100,20 @@ impl From<&ConnectionError> for DisconnectReason {
             | Json(_) => Self::ProtocolViolation,
             Io(_) => Self::Io,
             Crypto(_) | InterconnectFailure(_) => Self::Internal,
-            Ws(ws) => Self::WsClosed(match ws {
-                WsError::WsClosed(Some(frame)) => match frame.code {
-                    CloseCode::Library(l) => VoiceCloseCode::from_u16(l),
-                    _ => None,
-                },
-                _ => None,
-            }),
+            Ws(ws) => ws.into(),
             TimedOut => Self::TimedOut,
         }
+    }
+}
+
+impl From<&WsError> for DisconnectReason {
+    fn from(e: &WsError) -> Self {
+        Self::WsClosed(match e {
+            WsError::WsClosed(Some(frame)) => match frame.code {
+                CloseCode::Library(l) => VoiceCloseCode::from_u16(l),
+                _ => None,
+            },
+            _ => None,
+        })
     }
 }

--- a/src/events/context/data/disconnect.rs
+++ b/src/events/context/data/disconnect.rs
@@ -1,0 +1,113 @@
+use crate::{
+    error::ConnectionError,
+    id::*,
+    model::{CloseCode as VoiceCloseCode, FromPrimitive},
+    ws::Error as WsError,
+};
+#[cfg(not(feature = "tokio-02-marker"))]
+use async_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+#[cfg(feature = "tokio-02-marker")]
+use async_tungstenite_compat::tungstenite::protocol::frame::coding::CloseCode;
+
+/// Voice connection details gathered at termination or failure.
+///
+/// In the event of a failure, this event data is gathered after
+/// a reconnection strategy has exhausted all of its attempts.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct DisconnectData<'a> {
+    /// The location that a voice connection was terminated.
+    pub kind: DisconnectKind,
+    /// The cause of any connection failure.
+    ///
+    /// If `None`, then this disconnect was requested by the user in some way
+    /// (i.e., leaving or changing voice channels).
+    pub reason: Option<DisconnectReason>,
+    /// ID of the voice channel being joined, if it is known.
+    ///
+    /// If this is available, then this can be used to reconnect/renew
+    /// a voice session via thew gateway.
+    pub channel_id: Option<ChannelId>,
+    /// ID of the target voice channel's parent guild.
+    pub guild_id: GuildId,
+    /// Unique string describing this session for validation/authentication purposes.
+    pub session_id: &'a str,
+}
+
+/// The location that a voice connection was terminated.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum DisconnectKind {
+    /// The voice driver failed to connect to the server.
+    ///
+    /// This requires explicit handling at the gateway level
+    /// to either reconnect or fully disconnect.
+    Connect,
+    /// The voice driver failed to reconnect to the server.
+    ///
+    /// This requires explicit handling at the gateway level
+    /// to either reconnect or fully disconnect.
+    Reconnect,
+    /// The voice connection was terminated mid-session by either
+    /// the user or Discord.
+    ///
+    /// If `reason == None`, then this disconnection is either
+    /// a full disconnect or a user-requested channel change.
+    /// Otherwise, this is likely a session expiry (requiring user
+    /// handling to fully disconnect/reconnect).
+    Runtime,
+}
+
+/// The reason that a voice connection failed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum DisconnectReason {
+    /// This (re)connection attempt was dropped due to another request.
+    AttemptDiscarded,
+    /// Songbird had an internal error.
+    ///
+    /// This should never happen; if this is ever seen, raise an issue with logs.
+    Internal,
+    /// A host-specific I/O error caused the fault; this is likely transient, and
+    /// should be retried some time later.
+    Io,
+    /// Songbird and Discord disagreed on the protocol used to establish a
+    /// voice connection.
+    ///
+    /// This should never happen; if this is ever seen, raise an issue with logs.
+    ProtocolViolation,
+    /// A voice connection was not established in the specified time.
+    TimedOut,
+    /// The Websocket connection was closed by Discord.
+    ///
+    /// This typically indicates that the voice session has expired,
+    /// and a new one needs to be requested via the gateway.
+    WsClosed(Option<VoiceCloseCode>),
+}
+
+impl From<&ConnectionError> for DisconnectReason {
+    fn from(e: &ConnectionError) -> Self {
+        use ConnectionError::*;
+
+        match e {
+            AttemptDiscarded => Self::AttemptDiscarded,
+            CryptoModeInvalid
+            | CryptoModeUnavailable
+            | EndpointUrl
+            | ExpectedHandshake
+            | IllegalDiscoveryResponse
+            | IllegalIp
+            | Json(_) => Self::ProtocolViolation,
+            Io(_) => Self::Io,
+            Crypto(_) | InterconnectFailure(_) => Self::Internal,
+            Ws(ws) => Self::WsClosed(match ws {
+                WsError::WsClosed(Some(frame)) => match frame.code {
+                    CloseCode::Library(l) => VoiceCloseCode::from_u16(l),
+                    _ => None,
+                },
+                _ => None,
+            }),
+            TimedOut => Self::TimedOut,
+        }
+    }
+}

--- a/src/events/context/data/mod.rs
+++ b/src/events/context/data/mod.rs
@@ -2,10 +2,11 @@
 //!
 //! [`EventContext`]: super::EventContext
 mod connect;
+mod disconnect;
 mod rtcp;
 mod speaking;
 mod voice;
 
 use discortp::{rtcp::Rtcp, rtp::Rtp};
 
-pub use self::{connect::*, rtcp::*, speaking::*, voice::*};
+pub use self::{connect::*, disconnect::*, rtcp::*, speaking::*, voice::*};

--- a/src/events/context/internal_data.rs
+++ b/src/events/context/internal_data.rs
@@ -1,9 +1,10 @@
 use super::context_data::*;
+use crate::ConnectionInfo;
 use discortp::{rtcp::Rtcp, rtp::Rtp};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InternalConnect {
-    pub server: String,
+    pub info: ConnectionInfo,
     pub ssrc: u32,
 }
 
@@ -31,7 +32,10 @@ pub struct InternalRtcpPacket {
 impl<'a> From<&'a InternalConnect> for ConnectData<'a> {
     fn from(val: &'a InternalConnect) -> Self {
         Self {
-            server: &val.server,
+            channel_id: val.info.channel_id,
+            guild_id: val.info.guild_id,
+            session_id: &val.info.session_id,
+            server: &val.info.endpoint,
             ssrc: val.ssrc,
         }
     }

--- a/src/events/context/internal_data.rs
+++ b/src/events/context/internal_data.rs
@@ -8,6 +8,13 @@ pub struct InternalConnect {
     pub ssrc: u32,
 }
 
+#[derive(Debug)]
+pub struct InternalDisconnect {
+    pub kind: DisconnectKind,
+    pub reason: Option<DisconnectReason>,
+    pub info: ConnectionInfo,
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InternalSpeakingUpdate {
     pub ssrc: u32,
@@ -37,6 +44,18 @@ impl<'a> From<&'a InternalConnect> for ConnectData<'a> {
             session_id: &val.info.session_id,
             server: &val.info.endpoint,
             ssrc: val.ssrc,
+        }
+    }
+}
+
+impl<'a> From<&'a InternalDisconnect> for DisconnectData<'a> {
+    fn from(val: &'a InternalDisconnect) -> Self {
+        Self {
+            kind: val.kind,
+            reason: val.reason,
+            channel_id: val.info.channel_id,
+            guild_id: val.info.guild_id,
+            session_id: &val.info.session_id,
         }
     }
 }

--- a/src/events/core.rs
+++ b/src/events/core.rs
@@ -33,12 +33,22 @@ pub enum CoreEvent {
     DriverConnect,
     /// Fires when this driver successfully reconnects after a network error.
     DriverReconnect,
+    #[deprecated(
+        since = "0.2.0",
+        note = "Please use the DriverDisconnect event instead."
+    )]
     /// Fires when this driver fails to connect to a voice channel.
     DriverConnectFailed,
+    #[deprecated(
+        since = "0.2.0",
+        note = "Please use the DriverDisconnect event instead."
+    )]
     /// Fires when this driver fails to reconnect to a voice channel after a network error.
     ///
     /// Users will need to manually reconnect on receipt of this error.
     DriverReconnectFailed,
+    /// Fires when this driver fails to connect to, or drops from, a voice channel.
+    DriverDisconnect,
     /// Fires whenever the driver is assigned a new [RTP SSRC] by the voice server.
     ///
     /// This typically fires alongside a [DriverConnect], or a full [DriverReconnect].

--- a/src/info.rs
+++ b/src/info.rs
@@ -104,7 +104,7 @@ impl ConnectionProgress {
 
 /// Parameters and information needed to start communicating with Discord's voice servers, either
 /// with the Songbird driver, lavalink, or other system.
-#[derive(Clone)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct ConnectionInfo {
     /// ID of the voice channel being joined, if it is known.
     ///


### PR DESCRIPTION
This PR adds several enhancements to Driver connection logic:
* Driver (re)connection attempts now have a default timeout of around 10s.
* The driver will now attempt to retry full connection attempts using a user-provided strategy: currently, this defaults to 5 attempts under an exponential backoff strategy.
* The driver will now fire `DriverDisconnect` events at the end of any session -- this unifies (re)connection failure events with session expiry as seen in #76, which should provide users with enough detail to know *which* voice channel to reconnect to. Users still need to be careful to read the session/channel IDs to ensure that they aren't overwriting another join.

This has been tested using `cargo make ready`, and by setting low timeouts to force failures in the voice receive example (with some additional error handlers).

Closes #68.