### PR TITLE
Fix for underflow by clamping

### DIFF
--- a/src/input/metadata.rs
+++ b/src/input/metadata.rs
@@ -47,7 +47,7 @@ impl Metadata {
         let start_time = format
             .and_then(|m| m.get("start_time"))
             .and_then(Value::as_str)
-            .and_then(|v| v.parse::<f64>().ok())
+            .and_then(|v| v.parse::<f64>().ok().map(|t| t.max(0.0)))
             .map(Duration::from_secs_f64);
 
         let tags = format.and_then(|m| m.get("tags"));


### PR DESCRIPTION
Clamp the start time to 0 as a potential fix for underflow when playing sounds