### PR TITLE
Tracks: Remove box around TrackState

### DIFF
--- a/src/tracks/command.rs
+++ b/src/tracks/command.rs
@@ -26,8 +26,8 @@ pub enum TrackCommand {
     AddEvent(EventData),
     /// Run some closure on this track, with direct access to the core object.
     Do(Box<dyn FnOnce(&mut Track) + Send + Sync + 'static>),
-    /// Request a read-only view of this track's state.
-    Request(Sender<Box<TrackState>>),
+    /// Request a copy of this track's state.
+    Request(Sender<TrackState>),
     /// Change the loop count/strategy of this track.
     Loop(LoopState),
     /// Prompts a track's input to become live and usable, if it is not already.

--- a/src/tracks/handle.rs
+++ b/src/tracks/handle.rs
@@ -162,7 +162,7 @@ impl TrackHandle {
     }
 
     /// Request playback information and state from the audio context.
-    pub async fn get_info(&self) -> TrackResult<Box<TrackState>> {
+    pub async fn get_info(&self) -> TrackResult<TrackState> {
         let (tx, rx) = flume::bounded(1);
         self.send(TrackCommand::Request(tx))?;
 

--- a/src/tracks/mod.rs
+++ b/src/tracks/mod.rs
@@ -294,7 +294,7 @@ impl Track {
                             ));
                         },
                         Request(tx) => {
-                            let _ = tx.send(Box::new(self.state()));
+                            let _ = tx.send(self.state());
                         },
                         Loop(loops) =>
                             if self.set_loops(loops).is_ok() {


### PR DESCRIPTION
Boxing is unnecessary since `TrackState` implements copy.

Tested using `cargo make ready`