### PR TITLE
Deps: Bump twilight versions -> 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,12 +105,12 @@ default-features = false
 
 [dependencies.twilight-gateway]
 optional = true
-version = "0.6"
+version = ">=0.5, <0.7"
 default-features = false
 
 [dependencies.twilight-model]
 optional = true
-version = "0.6"
+version = ">=0.5, <0.7"
 default-features = false
 
 [dependencies.typemap_rev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,12 +105,12 @@ default-features = false
 
 [dependencies.twilight-gateway]
 optional = true
-version = "0.5"
+version = "0.6"
 default-features = false
 
 [dependencies.twilight-model]
 optional = true
-version = "0.5"
+version = "0.6"
 default-features = false
 
 [dependencies.typemap_rev]

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -8,14 +8,13 @@ edition = "2018"
 futures = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.2"
-serde_json = { version = "1" }
 tokio = { features = ["macros", "rt-multi-thread", "sync"], version = "1" }
-twilight-gateway = "0.5"
-twilight-http = "0.5"
-twilight-model = "0.5"
-twilight-standby = "0.5"
+twilight-gateway = "0.6"
+twilight-http = "0.6"
+twilight-model = "0.6"
+twilight-standby = "0.6"
 
 [dependencies.songbird]
-path = "../.."
 default-features = false
-features = ["twilight-rustls", "gateway", "driver", "zlib-stock"]
+path = "../.."
+features = ["driver", "twilight-rustls", "zlib-stock"]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -87,7 +87,7 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight<U>(cluster: Cluster, user_id: U) -> Arc<Self>
+    pub fn twilight<U>(cluster: Cluster, user_id: U) -> Self
     where
         U: Into<UserId>,
     {
@@ -102,11 +102,11 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight_from_config<U>(cluster: Cluster, user_id: U, config: Config) -> Arc<Self>
+    pub fn twilight_from_config<U>(cluster: Cluster, user_id: U, config: Config) -> Self
     where
         U: Into<UserId>,
     {
-        Arc::new(Self {
+        Self {
             client_data: PRwLock::new(ClientData {
                 shard_count: cluster
                     .config()
@@ -119,7 +119,7 @@ impl Songbird {
             calls: Default::default(),
             sharder: Sharder::Twilight(cluster),
             config: Some(config).into(),
-        })
+        }
     }
 
     /// Set the bot's user, and the number of shards in use.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -87,11 +87,11 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight<U>(cluster: Cluster, shard_count: u64, user_id: U) -> Arc<Self>
+    pub fn twilight<U>(cluster: Cluster, user_id: U) -> Arc<Self>
     where
         U: Into<UserId>,
     {
-        Self::twilight_from_config(cluster, shard_count, user_id, Default::default())
+        Self::twilight_from_config(cluster, user_id, Default::default())
     }
 
     #[cfg(feature = "twilight")]
@@ -102,18 +102,17 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight_from_config<U>(
-        cluster: Cluster,
-        shard_count: u64,
-        user_id: U,
-        config: Config,
-    ) -> Arc<Self>
+    pub fn twilight_from_config<U>(cluster: Cluster, user_id: U, config: Config) -> Arc<Self>
     where
         U: Into<UserId>,
     {
         Arc::new(Self {
             client_data: PRwLock::new(ClientData {
-                shard_count,
+                shard_count: cluster
+                    .config()
+                    .shard_scheme()
+                    .total()
+                    .unwrap_or_else(|| cluster.shards().len() as u64),
                 initialised: true,
                 user_id: user_id.into(),
             }),


### PR DESCRIPTION
Includes two more small changes too small to warrant PRs.
1. Removes the `shard_count` parameter from `Songbird::twilight` & `Songbird::twilight_from_config` since the cluster contains it.
2. Drops the `Arc` wrapper around `Songbird` to match against an upcoming twilight 0.7 change