### PR TITLE
Deps: Bump streamcatcher versions -> 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ version = "1"
 
 [dependencies.streamcatcher]
 optional = true
-version = "0.1"
+version = "1"
 
 [dependencies.tokio]
 optional = true


### PR DESCRIPTION
[streamcatcher](https://github.com/FelixMcFelix/streamcatcher) has major updated [v0.1.1 -> v1.0.0](https://github.com/FelixMcFelix/streamcatcher/compare/v0.1.1...v1.0.0). but it's small and doesn't seem to have breaking changes.

this fix https://rustsec.org/advisories/RUSTSEC-2020-0151
I received these messages by [https://github.com/EmbarkStudios/cargo-deny](https://github.com/EmbarkStudios/cargo-deny) about it.
```
error[A001]: Generators can cause data races if non-Send types are used in their generator functions
   ┌─ /workspace/Cargo.lock:71:1
   │
71 │ generator 0.6.25 registry+https://github.com/rust-lang/crates.io-index
   │ ---------------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2020-0151
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2020-0151
   = The `Generator` type is an iterable which uses a generator function that yields
     values. In affected versions of the crate, the provided function yielding values
     had no `Send` bounds despite the `Generator` itself implementing `Send`.
     
     The generator function lacking a `Send` bound means that types that are
     dangerous to send across threads such as `Rc` could be sent as part of a
     generator, potentially leading to data races.
     
     This flaw was fixed in commit [`f7d120a3b`](https://github.com/Xudong-Huang/generator-rs/commit/f7d120a3b724d06a7b623d0a4306acf8f78cb4f0)
     by enforcing that the generator function be bound by `Send`.
   = Announcement: https://github.com/Xudong-Huang/generator-rs/issues/27
   = Solution: Upgrade to >=0.7.0
   = generator v0.6.25
     └── loom v0.3.6
         └── streamcatcher v0.1.1
             └── songbird v0.2.0
```