### PR TITLE
Events: fix handling of multiple timed events on a single track

### DIFF
--- a/src/events/data.rs
+++ b/src/events/data.rs
@@ -66,7 +66,7 @@ impl Ord for EventData {
                 .as_ref()
                 .expect("T2 known to be well-defined by above.");
 
-            t1.cmp(t2)
+            t2.cmp(t1)
         } else {
             Ordering::Equal
         }


### PR DESCRIPTION
Fixes an issue where the `EventData` were not stored in reverse order, meaning that only the last added TimedEvent would be serviced.

This reverses the `Ord` for `EventData`, which should only be internally compared, allowing all timed events to be processed correctly in order.

Fixes #95.