### PR TITLE
Gateway: Add generics to `Call` methods.

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -155,7 +155,15 @@ impl Songbird {
     /// This will not join any calls, or cause connection state to change.
     ///
     /// [`Call`]: Call
-    pub fn get_or_insert(&self, guild_id: GuildId) -> Arc<Mutex<Call>> {
+    #[inline]
+    pub fn get_or_insert<G>(&self, guild_id: G) -> Arc<Mutex<Call>>
+    where
+        G: Into<GuildId>,
+    {
+        self._get_or_insert(guild_id.into())
+    }
+
+    fn _get_or_insert(&self, guild_id: GuildId) -> Arc<Mutex<Call>> {
         self.get(guild_id).unwrap_or_else(|| {
             self.calls
                 .entry(guild_id)
@@ -378,7 +386,7 @@ impl Songbird {
 
                 if let Some(call) = call {
                     let mut handler = call.lock().await;
-                    handler.update_state(v.0.session_id.clone(), v.0.channel_id.map(Into::into));
+                    handler.update_state(v.0.session_id.clone(), v.0.channel_id);
                 }
             },
             _ => {},
@@ -432,10 +440,7 @@ impl VoiceGatewayManager for Songbird {
 
         if let Some(call) = self.get(guild_id) {
             let mut handler = call.lock().await;
-            handler.update_state(
-                voice_state.session_id.clone(),
-                voice_state.channel_id.map(Into::into),
-            );
+            handler.update_state(voice_state.session_id.clone(), voice_state.channel_id);
         }
     }
 }


### PR DESCRIPTION
Adds generics to any `Id` types on `Call`. Also includes the overlooked `Songbird::get_or_insert`.

Closes #94. Tested using `cargo make ready`.