### PR TITLE
Gateway: Remove lifetime from Serenity setup trait

### DIFF
--- a/src/serenity.rs
+++ b/src/serenity.rs
@@ -70,7 +70,7 @@ pub trait SerenityInit {
     fn register_songbird_from_config(self, config: Config) -> Self;
 }
 
-impl SerenityInit for ClientBuilder<'_> {
+impl SerenityInit for ClientBuilder {
     fn register_songbird(self) -> Self {
         register(self)
     }


### PR DESCRIPTION
This matches a recent serenity change where `ClientBuilder` no longer has an explicit lifetime parameter.

This was tested using `cargo make ready`.