### PR TITLE
Gateway: Generic Shard and Twilight v0.8 Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/serenity-rs/songbird.git"
 version = "0.2.1"
 
 [dependencies]
+derivative = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = { version = "0.1", features = ["log"] }
@@ -105,12 +106,12 @@ default-features = false
 
 [dependencies.twilight-gateway]
 optional = true
-version = ">=0.5, <0.7"
+version = "0.8"
 default-features = false
 
 [dependencies.twilight-model]
 optional = true
-version = ">=0.5, <0.7"
+version = "0.8"
 default-features = false
 
 [dependencies.typemap_rev]

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -9,10 +9,10 @@ futures = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { features = ["macros", "rt-multi-thread", "sync"], version = "1" }
-twilight-gateway = "0.6"
-twilight-http = "0.6"
-twilight-model = "0.6"
-twilight-standby = "0.6"
+twilight-gateway = "0.8"
+twilight-http = "0.8"
+twilight-model = "0.8"
+twilight-standby = "0.8"
 
 [dependencies.songbird]
 default-features = false

--- a/examples/twilight/src/main.rs
+++ b/examples/twilight/src/main.rs
@@ -30,14 +30,13 @@ use std::{collections::HashMap, env, error::Error, future::Future, sync::Arc};
 use tokio::sync::RwLock;
 use twilight_gateway::{Cluster, Event, Intents};
 use twilight_http::Client as HttpClient;
-use twilight_model::{channel::Message, gateway::payload::MessageCreate, id::GuildId};
+use twilight_model::{channel::Message, gateway::payload::incoming::MessageCreate, id::GuildId};
 use twilight_standby::Standby;
 
 type State = Arc<StateRef>;
 
 #[derive(Debug)]
 struct StateRef {
-    cluster: Cluster,
     http: HttpClient,
     trackdata: RwLock<HashMap<GuildId, TrackHandle>>,
     songbird: Songbird,
@@ -69,12 +68,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let (cluster, events) = Cluster::new(token, intents).await?;
         cluster.up().await;
 
-        let songbird = Songbird::twilight(cluster.clone(), user_id);
+        let songbird = Songbird::twilight(Arc::new(cluster), user_id);
 
         (
             events,
             Arc::new(StateRef {
-                cluster,
                 http,
                 trackdata: Default::default(),
                 songbird,

--- a/src/id.rs
+++ b/src/id.rs
@@ -50,7 +50,7 @@ impl From<SerenityChannel> for ChannelId {
 #[cfg(feature = "twilight")]
 impl From<TwilightChannel> for ChannelId {
     fn from(id: TwilightChannel) -> Self {
-        Self(id.0)
+        Self(id.0.into())
     }
 }
 
@@ -83,7 +83,7 @@ impl From<GuildId> for DriverGuild {
 #[cfg(feature = "twilight")]
 impl From<TwilightGuild> for GuildId {
     fn from(id: TwilightGuild) -> Self {
-        Self(id.0)
+        Self(id.0.into())
     }
 }
 
@@ -116,6 +116,6 @@ impl From<UserId> for DriverUser {
 #[cfg(feature = "twilight")]
 impl From<TwilightUser> for UserId {
     fn from(id: TwilightUser) -> Self {
-        Self(id.0)
+        Self(id.0.into())
     }
 }

--- a/src/input/dca.rs
+++ b/src/input/dca.rs
@@ -65,6 +65,7 @@ async fn _dca(path: &OsStr) -> Result<Input, DcaError> {
     ))
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct DcaMetadata {
     pub(crate) dca: Dca,
@@ -74,12 +75,14 @@ pub(crate) struct DcaMetadata {
     pub(crate) extra: Option<serde_json::Value>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Dca {
     pub(crate) version: u64,
     pub(crate) tool: Tool,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Tool {
     pub(crate) name: String,
@@ -88,6 +91,7 @@ pub(crate) struct Tool {
     pub(crate) author: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Opus {
     pub(crate) mode: String,
@@ -98,6 +102,7 @@ pub(crate) struct Opus {
     pub(crate) channels: u8,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Info {
     pub(crate) title: Option<String>,
@@ -107,6 +112,7 @@ pub(crate) struct Info {
     pub(crate) cover: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Origin {
     pub(crate) source: Option<String>,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -87,7 +87,7 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight<U>(cluster: Cluster, user_id: U) -> Self
+    pub fn twilight<U>(cluster: Arc<Cluster>, user_id: U) -> Self
     where
         U: Into<UserId>,
     {
@@ -102,7 +102,7 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight_from_config<U>(cluster: Cluster, user_id: U, config: Config) -> Self
+    pub fn twilight_from_config<U>(cluster: Arc<Cluster>, user_id: U, config: Config) -> Self
     where
         U: Into<UserId>,
     {
@@ -117,7 +117,7 @@ impl Songbird {
                 user_id: user_id.into(),
             }),
             calls: Default::default(),
-            sharder: Sharder::Twilight(cluster),
+            sharder: Sharder::TwilightCluster(cluster),
             config: Some(config).into(),
         }
     }
@@ -378,7 +378,7 @@ impl Songbird {
                 }
             },
             TwilightEvent::VoiceStateUpdate(v) => {
-                if v.0.user_id.0 != self.client_data.read().user_id.0 {
+                if v.0.user_id.0.get() != self.client_data.read().user_id.0 {
                     return;
                 }
 


### PR DESCRIPTION
This PR adds support to twilight v0.8, mainly adapting to significant API changes introduced by v0.7. As a result of these, twilight no longer accepts arbitrary JSON input, so it seemed sensible to adapt our `Shard` design to no longer require the same.

Adding to this, I've added in a trait to allow an arbitrary `Shard` to be installed, given only an implementation of a method to send a `VoiceStateUpdate`. Together, `Sharder::Generic` (songbird::shards::VoiceUpdate) and `Shard::Generic` (songbird::shards::GenericSharder) should allow any library to be hooked in to Songbird.

This PR was tested using `cargo make ready` and by manually testing `examples/twilight`.