### PR TITLE
Gateway: Twilight v0.9 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,12 +106,12 @@ default-features = false
 
 [dependencies.twilight-gateway]
 optional = true
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [dependencies.twilight-model]
 optional = true
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [dependencies.typemap_rev]
@@ -186,7 +186,7 @@ rustls = ["async-tungstenite/tokio-rustls-webpki-roots", "rustls-marker"]
 native = ["async-tungstenite/tokio-native-tls", "native-marker"]
 serenity-rustls = ["serenity/rustls_backend", "rustls", "gateway", "serenity-deps"]
 serenity-native = ["serenity/native_tls_backend", "native", "gateway", "serenity-deps"]
-twilight-rustls = ["twilight", "twilight-gateway/rustls", "rustls", "gateway"]
+twilight-rustls = ["twilight", "twilight-gateway/rustls-native-roots", "rustls", "gateway"]
 twilight-native = ["twilight", "twilight-gateway/native", "native", "gateway"]
 twilight = ["twilight-model"]
 zlib-simd = ["twilight-gateway/zlib-simd"]

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -9,10 +9,10 @@ futures = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { features = ["macros", "rt-multi-thread", "sync"], version = "1" }
-twilight-gateway = "0.8"
-twilight-http = "0.8"
-twilight-model = "0.8"
-twilight-standby = "0.8"
+twilight-gateway = "0.9"
+twilight-http = "0.9"
+twilight-model = "0.9"
+twilight-standby = "0.9"
 
 [dependencies.songbird]
 default-features = false

--- a/examples/twilight/src/main.rs
+++ b/examples/twilight/src/main.rs
@@ -30,7 +30,11 @@ use std::{collections::HashMap, env, error::Error, future::Future, sync::Arc};
 use tokio::sync::RwLock;
 use twilight_gateway::{Cluster, Event, Intents};
 use twilight_http::Client as HttpClient;
-use twilight_model::{channel::Message, gateway::payload::incoming::MessageCreate, id::GuildId};
+use twilight_model::{
+    channel::Message,
+    gateway::payload::incoming::MessageCreate,
+    id::{marker::GuildMarker, Id},
+};
 use twilight_standby::Standby;
 
 type State = Arc<StateRef>;
@@ -38,7 +42,7 @@ type State = Arc<StateRef>;
 #[derive(Debug)]
 struct StateRef {
     http: HttpClient,
-    trackdata: RwLock<HashMap<GuildId, TrackHandle>>,
+    trackdata: RwLock<HashMap<Id<GuildMarker>, TrackHandle>>,
     songbird: Songbird,
     standby: Standby,
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -11,9 +11,8 @@ use serenity::model::id::{
 use std::fmt::{Display, Formatter, Result as FmtResult};
 #[cfg(feature = "twilight")]
 use twilight_model::id::{
-    ChannelId as TwilightChannel,
-    GuildId as TwilightGuild,
-    UserId as TwilightUser,
+    marker::{ChannelMarker, GuildMarker, UserMarker},
+    Id as TwilightId,
 };
 
 /// ID of a Discord voice/text channel.
@@ -48,9 +47,9 @@ impl From<SerenityChannel> for ChannelId {
 }
 
 #[cfg(feature = "twilight")]
-impl From<TwilightChannel> for ChannelId {
-    fn from(id: TwilightChannel) -> Self {
-        Self(id.0.into())
+impl From<TwilightId<ChannelMarker>> for ChannelId {
+    fn from(id: TwilightId<ChannelMarker>) -> Self {
+        Self(id.get().into())
     }
 }
 
@@ -81,9 +80,9 @@ impl From<GuildId> for DriverGuild {
 }
 
 #[cfg(feature = "twilight")]
-impl From<TwilightGuild> for GuildId {
-    fn from(id: TwilightGuild) -> Self {
-        Self(id.0.into())
+impl From<TwilightId<GuildMarker>> for GuildId {
+    fn from(id: TwilightId<GuildMarker>) -> Self {
+        Self(id.get().into())
     }
 }
 
@@ -114,8 +113,8 @@ impl From<UserId> for DriverUser {
 }
 
 #[cfg(feature = "twilight")]
-impl From<TwilightUser> for UserId {
-    fn from(id: TwilightUser) -> Self {
-        Self(id.0.into())
+impl From<TwilightId<UserMarker>> for UserId {
+    fn from(id: TwilightId<UserMarker>) -> Self {
+        Self(id.get().into())
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -378,7 +378,7 @@ impl Songbird {
                 }
             },
             TwilightEvent::VoiceStateUpdate(v) => {
-                if v.0.user_id.0.get() != self.client_data.read().user_id.0 {
+                if v.0.user_id.get() != self.client_data.read().user_id.0 {
                     return;
                 }
 

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -20,10 +20,7 @@ use tracing::{debug, error};
 #[cfg(feature = "twilight")]
 use twilight_gateway::{Cluster, Shard as TwilightShard};
 #[cfg(feature = "twilight")]
-use twilight_model::{
-    gateway::payload::outgoing::update_voice_state::UpdateVoiceState as TwilightVoiceState,
-    id::ChannelId as TwilightChannel,
-};
+use twilight_model::gateway::payload::outgoing::update_voice_state::UpdateVoiceState as TwilightVoiceState;
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -191,14 +188,14 @@ impl VoiceUpdate for Shard {
             },
             #[cfg(feature = "twilight")]
             Shard::TwilightCluster(handle, shard_id) => {
-                let channel_id = nz_channel_id.map(TwilightChannel);
+                let channel_id = nz_channel_id.map(From::from);
                 let cmd = TwilightVoiceState::new(nz_guild_id, channel_id, self_deaf, self_mute);
                 handle.command(*shard_id, &cmd).await?;
                 Ok(())
             },
             #[cfg(feature = "twilight")]
             Shard::TwilightShard(handle) => {
-                let channel_id = nz_channel_id.map(TwilightChannel);
+                let channel_id = nz_channel_id.map(From::from);
                 let cmd = TwilightVoiceState::new(nz_guild_id, channel_id, self_deaf, self_mute);
                 handle.command(&cmd).await?;
                 Ok(())


### PR DESCRIPTION
This handles twilight's migration to a unified `Id` type, which is the only design change needing any handling on our part. All out `From`/`Into`s are covered now, and deprecated type aliases are no longer used.

This was tested using `cargo make ready` and by manually running "examples/twilight".