### PR TITLE
Events: Document format of `VoiceData`.

### DIFF
--- a/src/events/context/data/voice.rs
+++ b/src/events/context/data/voice.rs
@@ -5,7 +5,15 @@ use super::*;
 /// Opus audio packet, received from another stream (detailed in `packet`).
 /// `payload_offset` contains the true payload location within the raw packet's `payload()`,
 /// if extensions or raw packet data are required.
-/// If `audio.len() == 0`, then this packet arrived out-of-order.
+///
+/// Valid audio data (`Some(audio)` where `audio.len >= 0`) contains up to 20ms of 16-bit mono PCM audio
+/// at 48kHz, using native endianness. Songbird will not send audio for silent regions, these should
+/// be inferred using [`SpeakingUpdate`]s (and filled in by the user if required using arrays of zeroes).
+///
+/// If `audio.len() == 0`, then this packet arrived out-of-order. If `None`, songbird was not configured
+/// to decode received packets.
+///
+/// [`SpeakingUpdate`]: crate::events::CoreEvent::SpeakingUpdate
 pub struct VoiceData<'a> {
     /// Decoded audio from this packet.
     pub audio: &'a Option<Vec<i16>>,


### PR DESCRIPTION
This properly explains the audio data format used for decoded voice packet data, as well as how to handle silent blocks.

Closes #100.