### PR TITLE
Events: Remove deprecated events.

### DIFF
--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -7,7 +7,6 @@ use super::{
 };
 use crate::{
     constants::*,
-    events::CoreContext,
     model::{
         payload::{Identify, Resume, SelectProtocol},
         Event as GatewayEvent,
@@ -210,10 +209,6 @@ impl Connection {
         interconnect
             .mixer
             .send(MixerMessage::SetConn(mix_conn, ready.ssrc))?;
-
-        let _ = interconnect
-            .events
-            .send(EventMessage::FireCoreEvent(CoreContext::SsrcKnown(ssrc)));
 
         spawn(ws_task::runner(
             interconnect.clone(),

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -331,10 +331,6 @@ impl ConnectionRetryData {
                             let _ = tx.send(Err(why));
 
                             let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                                CoreContext::DriverConnectFailed,
-                            ));
-
-                            let _ = interconnect.events.send(EventMessage::FireCoreEvent(
                                 CoreContext::DriverDisconnect(InternalDisconnect {
                                     kind: DisconnectKind::Connect,
                                     reason,
@@ -343,10 +339,6 @@ impl ConnectionRetryData {
                             ));
                         },
                         ConnectionFlavour::Reconnect => {
-                            let _ = interconnect.events.send(EventMessage::FireCoreEvent(
-                                CoreContext::DriverReconnectFailed,
-                            ));
-
                             let _ = interconnect.events.send(EventMessage::FireCoreEvent(
                                 CoreContext::DriverDisconnect(InternalDisconnect {
                                     kind: DisconnectKind::Reconnect,

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -200,9 +200,7 @@ impl AuxNetwork {
                 ));
             },
             GatewayEvent::ClientConnect(ev) => {
-                let _ = interconnect
-                    .events
-                    .send(EventMessage::FireCoreEvent(CoreContext::ClientConnect(ev)));
+                debug!("Received discontinued ClientConnect: {:?}", ev);
             },
             GatewayEvent::ClientDisconnect(ev) => {
                 let _ = interconnect.events.send(EventMessage::FireCoreEvent(

--- a/src/events/context/mod.rs
+++ b/src/events/context/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod internal_data;
 
 use super::*;
 use crate::{
-    model::payload::{ClientConnect, ClientDisconnect, Speaking},
+    model::payload::{ClientDisconnect, Speaking},
     tracks::{TrackHandle, TrackState},
 };
 pub use data as context_data;
@@ -38,66 +38,14 @@ pub enum EventContext<'a> {
     VoicePacket(VoiceData<'a>),
     /// Telemetry/statistics packet, received from another stream.
     RtcpPacket(RtcpData<'a>),
-    #[deprecated(
-        since = "0.2.2",
-        note = "ClientConnect events are no longer sent by Discord. Please use SpeakingStateUpdate or Discord gateway events."
-    )]
-    /// Formerly fired whenever a client connects to a call for the first time, allowing SSRC/UserID
-    /// matching. This event no longer fires.
-    ///
-    /// To detect when a user connects, you must correlate gateway (e.g., VoiceStateUpdate) events
-    /// from the main part of your bot.
-    ///
-    /// To obtain a user's SSRC, you must use [`SpeakingStateUpdate`] events.
-    ///
-    /// [`SpeakingStateUpdate`]: Self::SpeakingStateUpdate
-    ClientConnect(ClientConnect),
     /// Fired whenever a client disconnects.
     ClientDisconnect(ClientDisconnect),
     /// Fires when this driver successfully connects to a voice channel.
     DriverConnect(ConnectData<'a>),
     /// Fires when this driver successfully reconnects after a network error.
     DriverReconnect(ConnectData<'a>),
-    #[deprecated(
-        since = "0.2.0",
-        note = "Please use the DriverDisconnect event instead."
-    )]
-    /// Fires when this driver fails to connect to a voice channel.
-    ///
-    /// Users will need to manually reconnect on receipt of this error.
-    /// **This event is deprecated in favour of [`DriverDisconnect`].**
-    ///
-    /// [`DriverDisconnect`]: Self::DriverDisconnect
-    // TODO: remove in 0.3.x
-    DriverConnectFailed,
-    #[deprecated(
-        since = "0.2.0",
-        note = "Please use the DriverDisconnect event instead."
-    )]
-    /// Fires when this driver fails to reconnect to a voice channel after a network error.
-    ///
-    /// Users will need to manually reconnect on receipt of this error.
-    /// **This event is deprecated in favour of [`DriverDisconnect`].**
-    ///
-    /// [`DriverDisconnect`]: Self::DriverDisconnect
-    // TODO: remove in 0.3.x
-    DriverReconnectFailed,
     /// Fires when this driver fails to connect to, or drops from, a voice channel.
     DriverDisconnect(DisconnectData<'a>),
-    #[deprecated(
-        since = "0.2.0",
-        note = "Please use the DriverConnect/Reconnect events instead."
-    )]
-    /// Fires whenever the driver is assigned a new [RTP SSRC] by the voice server.
-    ///
-    /// This typically fires alongside a [DriverConnect], or a full [DriverReconnect].
-    /// **This event is *deprecated* in favour of these alternatives**.
-    ///
-    /// [RTP SSRC]: https://tools.ietf.org/html/rfc3550#section-3
-    /// [DriverConnect]: Self::DriverConnect
-    /// [DriverReconnect]: Self::DriverReconnect
-    // TODO: remove in 0.3.x
-    SsrcKnown(u32),
 }
 
 #[derive(Debug)]
@@ -106,14 +54,10 @@ pub enum CoreContext {
     SpeakingUpdate(InternalSpeakingUpdate),
     VoicePacket(InternalVoicePacket),
     RtcpPacket(InternalRtcpPacket),
-    ClientConnect(ClientConnect),
     ClientDisconnect(ClientDisconnect),
     DriverConnect(InternalConnect),
     DriverReconnect(InternalConnect),
     DriverDisconnect(InternalDisconnect),
-    DriverConnectFailed,
-    DriverReconnectFailed,
-    SsrcKnown(u32),
 }
 
 impl<'a> CoreContext {
@@ -125,18 +69,10 @@ impl<'a> CoreContext {
             SpeakingUpdate(evt) => EventContext::SpeakingUpdate(SpeakingUpdateData::from(evt)),
             VoicePacket(evt) => EventContext::VoicePacket(VoiceData::from(evt)),
             RtcpPacket(evt) => EventContext::RtcpPacket(RtcpData::from(evt)),
-            #[allow(deprecated)]
-            ClientConnect(evt) => EventContext::ClientConnect(*evt),
             ClientDisconnect(evt) => EventContext::ClientDisconnect(*evt),
             DriverConnect(evt) => EventContext::DriverConnect(ConnectData::from(evt)),
             DriverReconnect(evt) => EventContext::DriverReconnect(ConnectData::from(evt)),
             DriverDisconnect(evt) => EventContext::DriverDisconnect(DisconnectData::from(evt)),
-            #[allow(deprecated)]
-            DriverConnectFailed => EventContext::DriverConnectFailed,
-            #[allow(deprecated)]
-            DriverReconnectFailed => EventContext::DriverReconnectFailed,
-            #[allow(deprecated)]
-            SsrcKnown(s) => EventContext::SsrcKnown(*s),
         }
     }
 }
@@ -152,18 +88,10 @@ impl EventContext<'_> {
             SpeakingUpdate(_) => Some(CoreEvent::SpeakingUpdate),
             VoicePacket(_) => Some(CoreEvent::VoicePacket),
             RtcpPacket(_) => Some(CoreEvent::RtcpPacket),
-            #[allow(deprecated)]
-            ClientConnect(_) => Some(CoreEvent::ClientConnect),
             ClientDisconnect(_) => Some(CoreEvent::ClientDisconnect),
             DriverConnect(_) => Some(CoreEvent::DriverConnect),
             DriverReconnect(_) => Some(CoreEvent::DriverReconnect),
             DriverDisconnect(_) => Some(CoreEvent::DriverDisconnect),
-            #[allow(deprecated)]
-            DriverConnectFailed => Some(CoreEvent::DriverConnectFailed),
-            #[allow(deprecated)]
-            DriverReconnectFailed => Some(CoreEvent::DriverReconnectFailed),
-            #[allow(deprecated)]
-            SsrcKnown(_) => Some(CoreEvent::SsrcKnown),
             _ => None,
         }
     }

--- a/src/events/core.rs
+++ b/src/events/core.rs
@@ -4,10 +4,29 @@
 /// Core events persist while the `action` in [`EventData`]
 /// returns `None`.
 ///
+/// ## Events from other users
+/// Songbird can observe when a user *speaks for the first time* ([`SpeakingStateUpdate`]),
+/// when a client leaves the session ([`ClientDisconnect`]), voice packets ([`VoicePacket`]), and
+/// telemetry data ([`RtcpPacket`]). The format of voice packets is described by [`VoiceData`].
+///
+/// To detect when a user connects, you must correlate gateway (e.g., VoiceStateUpdate) events
+/// from the main part of your bot.
+///
+/// To obtain a user's SSRC, you must use [`SpeakingStateUpdate`] events.
+///
 /// [`EventData`]: super::EventData
+/// [`VoiceData`]: super::context::data::VoiceData
+/// [`SpeakingStateUpdate`]: Self::SpeakingStateUpdate
+/// [`ClientDisconnect`]: Self::ClientDisconnect
+/// [`VoicePacket`]: Self::VoicePacket
+/// [`RtcpPacket`]: Self::RtcpPacket
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum CoreEvent {
+    /// Speaking state update, typically describing how another voice
+    /// user is transmitting audio data. Clients must send at least one such
+    /// packet to allow SSRC/UserID matching.
+    ///
     /// Fired on receipt of a speaking state update from another host.
     ///
     /// Note: this will fire when a user starts speaking for the first time,
@@ -25,52 +44,12 @@ pub enum CoreEvent {
     /// Fires on receipt of an RTCP packet, containing various call stats
     /// such as latency reports.
     RtcpPacket,
-    #[deprecated(
-        since = "0.2.2",
-        note = "ClientConnect events are no longer sent by Discord. Please use SpeakingStateUpdate or Discord gateway events."
-    )]
-    /// Formerly fired whenever a client connects to a call for the first time, allowing SSRC/UserID
-    /// matching. This event no longer fires.
-    ///
-    /// To detect when a user connects, you must correlate gateway (e.g., VoiceStateUpdate) events
-    /// from the main part of your bot.
-    ///
-    /// To obtain a user's SSRC, you must use [`SpeakingStateUpdate`] events.
-    ///
-    /// [`SpeakingStateUpdate`]: Self::SpeakingStateUpdate
-    ClientConnect,
     /// Fires whenever a user disconnects from the same stream as the bot.
     ClientDisconnect,
     /// Fires when this driver successfully connects to a voice channel.
     DriverConnect,
     /// Fires when this driver successfully reconnects after a network error.
     DriverReconnect,
-    #[deprecated(
-        since = "0.2.0",
-        note = "Please use the DriverDisconnect event instead."
-    )]
-    /// Fires when this driver fails to connect to a voice channel.
-    DriverConnectFailed,
-    #[deprecated(
-        since = "0.2.0",
-        note = "Please use the DriverDisconnect event instead."
-    )]
-    /// Fires when this driver fails to reconnect to a voice channel after a network error.
-    ///
-    /// Users will need to manually reconnect on receipt of this error.
-    DriverReconnectFailed,
     /// Fires when this driver fails to connect to, or drops from, a voice channel.
     DriverDisconnect,
-    /// Fires whenever the driver is assigned a new [RTP SSRC] by the voice server.
-    ///
-    /// This typically fires alongside a [DriverConnect], or a full [DriverReconnect].
-    ///
-    /// [RTP SSRC]: https://tools.ietf.org/html/rfc3550#section-3
-    /// [DriverConnect]: Self::DriverConnect
-    /// [DriverReconnect]: Self::DriverReconnect
-    #[deprecated(
-        since = "0.2.0",
-        note = "Please use the DriverConnect/Reconnect events instead."
-    )]
-    SsrcKnown,
 }


### PR DESCRIPTION
This removes the `ClientConnect`, `DriverConnectFailed`, `DriverReconnectFailed` and `SsrcKnown` events.

Tested using `cargo make ready`.