### PR TITLE
feat: return track handle when adding an `Input` to the queue

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -281,10 +281,11 @@ impl Driver {
     /// Requires the `"builtin-queue"` feature.
     ///
     /// [`Input`]: crate::input::Input
-    pub fn enqueue_source(&mut self, source: Input) {
-        let (mut track, _) = tracks::create_player(source);
-        self.queue.add_raw(&mut track);
-        self.play(track);
+    pub fn enqueue_source(&mut self, source: Input) -> TrackHandle {
+        let (track, handle) = tracks::create_player(source);
+        self.enqueue(track);
+
+        handle
     }
 
     /// Adds an existing [`Track`] to this driver's built-in queue.

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -165,9 +165,11 @@ impl TrackQueue {
     }
 
     /// Adds an audio source to the queue, to be played in the channel managed by `handler`.
-    pub fn add_source(&self, source: Input, handler: &mut Driver) {
-        let (audio, _) = tracks::create_player(source);
-        self.add(audio, handler);
+    pub fn add_source(&self, source: Input, handler: &mut Driver) -> TrackHandle {
+        let (track, handle) = tracks::create_player(source);
+        self.add(track, handler);
+
+        handle
     }
 
     /// Adds a [`Track`] object to the queue, to be played in the channel managed by `handler`.


### PR DESCRIPTION
This modifies `Driver::enqueue_source` and `TrackQueue::add_source` to return the created track handle. This can be useful if you want to e.g. access the metadata after adding it and makes it more consistent with `Driver::play_source`, which returns the handle as well. 