### PR TITLE
Remove tokio 0.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,6 @@ jobs:
           - name: gateway only
             features: serenity-rustls
             dont-test: true
-          - name: legacy tokio
-            features: serenity-rustls-tokio-02 driver-tokio-02
-            dont-test: true
 
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,6 @@ features = ["tokio-runtime"]
 optional = true
 version = "0.14"
 
-[dependencies.async-tungstenite-compat]
-package = "async-tungstenite"
-default-features = false
-features = ["tokio-runtime"]
-optional = true
-version = "0.9"
-
 [dependencies.audiopus]
 optional = true
 version = "0.2"
@@ -96,12 +89,6 @@ version = "1"
 [dependencies.tokio]
 optional = true
 version = "1.0"
-default-features = false
-
-[dependencies.tokio-compat]
-optional = true
-package = "tokio"
-version = "0.2"
 default-features = false
 
 [dependencies.twilight-gateway]
@@ -195,32 +182,6 @@ serenity-deps = ["async-trait"]
 
 rustls-marker = []
 native-marker = []
-
-# Tokio 0.2 Compatibility features
-# These should probably be dropped around the same time as serenity drop them.
-rustls-tokio-02 = ["async-tungstenite-compat/tokio-rustls", "rustls-marker", "tokio-02-marker"]
-native-tokio-02 = ["async-tungstenite-compat/tokio-native-tls", "native-marker", "tokio-02-marker"]
-serenity-rustls-tokio-02 = ["serenity/rustls_tokio_0_2_backend", "rustls-tokio-02", "gateway-tokio-02", "serenity-deps"]
-serenity-native-tokio-02 = ["serenity/native_tls_tokio_0_2_backend", "native-tokio-02", "gateway-tokio-02", "serenity-deps"]
-gateway-tokio-02 = [
-    "gateway-core",
-    "tokio-02-marker",
-    "tokio-compat/sync",
-]
-driver-tokio-02 = [
-    "async-tungstenite-compat",
-    "driver-core",
-    "tokio-02-marker",
-    "tokio-compat/fs",
-    "tokio-compat/io-util",
-    "tokio-compat/macros",
-    "tokio-compat/net",
-    "tokio-compat/process",
-    "tokio-compat/rt-core",
-    "tokio-compat/sync",
-    "tokio-compat/time",
-]
-tokio-02-marker = []
 
 # Behaviour altering features.
 youtube-dlc = []

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -23,13 +23,8 @@ args = ["build", "--no-default-features", "--features", "driver,rustls"]
 command = "cargo"
 dependencies = ["format"]
 
-[tasks.build-old-tokio]
-command = "cargo"
-args = ["build", "--no-default-features", "--features", "serenity-rustls-tokio-02,driver-tokio-02"]
-dependencies = ["format"]
-
 [tasks.build-variants]
-dependencies = ["build", "build-gateway", "build-driver", "build-old-tokio"]
+dependencies = ["build", "build-gateway", "build-driver"]
 
 [tasks.clippy]
 args = ["clippy", "--features", "full-doc", "--", "-D", "warnings"]

--- a/src/driver/connection/error.rs
+++ b/src/driver/connection/error.rs
@@ -7,10 +7,7 @@ use crate::{
 use flume::SendError;
 use serde_json::Error as JsonError;
 use std::{error::Error as StdError, fmt, io::Error as IoError};
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::time::error::Elapsed;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::time::Elapsed;
 use xsalsa20poly1305::aead::Error as CryptoError;
 
 /// Errors encountered while connecting to a Discord voice server over the driver.

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -19,10 +19,7 @@ use discortp::discord::{IpDiscoveryPacket, IpDiscoveryType, MutableIpDiscoveryPa
 use error::{Error, Result};
 use flume::Sender;
 use std::{net::IpAddr, str::FromStr, sync::Arc};
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{net::UdpSocket, spawn, time::timeout};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{net::UdpSocket, spawn, time::timeout};
 use tracing::{debug, info, instrument};
 use url::Url;
 use xsalsa20poly1305::{aead::NewAead, XSalsa20Poly1305 as Cipher};
@@ -115,11 +112,7 @@ impl Connection {
             return Err(Error::CryptoModeUnavailable);
         }
 
-        #[cfg(not(feature = "tokio-02-marker"))]
         let udp = UdpSocket::bind("0.0.0.0:0").await?;
-        #[cfg(feature = "tokio-02-marker")]
-        let mut udp = UdpSocket::bind("0.0.0.0:0").await?;
-
         udp.connect((ready.ip, ready.port)).await?;
 
         // Follow Discord's IP Discovery procedures, in case NAT tunnelling is needed.
@@ -184,14 +177,11 @@ impl Connection {
         let (udp_sender_msg_tx, udp_sender_msg_rx) = flume::unbounded();
         let (udp_receiver_msg_tx, udp_receiver_msg_rx) = flume::unbounded();
 
-        #[cfg(not(feature = "tokio-02-marker"))]
         let (udp_rx, udp_tx) = {
             let udp_rx = Arc::new(udp);
             let udp_tx = Arc::clone(&udp_rx);
             (udp_rx, udp_tx)
         };
-        #[cfg(feature = "tokio-02-marker")]
-        let (udp_rx, udp_tx) = udp.split();
 
         let ssrc = ready.ssrc;
 

--- a/src/driver/tasks/message/mod.rs
+++ b/src/driver/tasks/message/mod.rs
@@ -11,10 +11,7 @@ mod ws;
 pub use self::{core::*, disposal::*, events::*, mixer::*, udp_rx::*, udp_tx::*, ws::*};
 
 use flume::Sender;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::spawn;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::spawn;
 use tracing::trace;
 
 #[derive(Clone, Debug)]

--- a/src/driver/tasks/mixer.rs
+++ b/src/driver/tasks/mixer.rs
@@ -19,10 +19,7 @@ use flume::{Receiver, Sender, TryRecvError};
 use rand::random;
 use spin_sleep::SpinSleeper;
 use std::time::Instant;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::runtime::Handle;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::runtime::Handle;
 use tracing::{debug, error, instrument};
 use xsalsa20poly1305::TAG_SIZE;
 

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -23,10 +23,7 @@ use crate::{
 };
 use flume::{Receiver, RecvError, Sender};
 use message::*;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{runtime::Handle, spawn, time::sleep as tsleep};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{runtime::Handle, spawn, time::delay_for as tsleep};
 use tracing::{debug, instrument, trace};
 
 pub(crate) fn start(config: Config, rx: Receiver<CoreMessage>, tx: Sender<CoreMessage>) {

--- a/src/driver/tasks/udp_rx.rs
+++ b/src/driver/tasks/udp_rx.rs
@@ -22,10 +22,7 @@ use discortp::{
 };
 use flume::Receiver;
 use std::{collections::HashMap, sync::Arc};
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{net::UdpSocket, select};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{net::udp::RecvHalf, select};
 use tracing::{error, instrument, trace, warn};
 use xsalsa20poly1305::XSalsa20Poly1305 as Cipher;
 
@@ -241,10 +238,7 @@ struct UdpRx {
     packet_buffer: [u8; VOICE_PACKET_MAX],
     rx: Receiver<UdpRxMessage>,
 
-    #[cfg(not(feature = "tokio-02-marker"))]
     udp_socket: Arc<UdpSocket>,
-    #[cfg(feature = "tokio-02-marker")]
-    udp_socket: RecvHalf,
 }
 
 impl UdpRx {
@@ -396,7 +390,6 @@ impl UdpRx {
     }
 }
 
-#[cfg(not(feature = "tokio-02-marker"))]
 #[instrument(skip(interconnect, rx, cipher))]
 pub(crate) async fn runner(
     mut interconnect: Interconnect,
@@ -404,31 +397,6 @@ pub(crate) async fn runner(
     cipher: Cipher,
     config: Config,
     udp_socket: Arc<UdpSocket>,
-) {
-    trace!("UDP receive handle started.");
-
-    let mut state = UdpRx {
-        cipher,
-        decoder_map: Default::default(),
-        config,
-        packet_buffer: [0u8; VOICE_PACKET_MAX],
-        rx,
-        udp_socket,
-    };
-
-    state.run(&mut interconnect).await;
-
-    trace!("UDP receive handle stopped.");
-}
-
-#[cfg(feature = "tokio-02-marker")]
-#[instrument(skip(interconnect, rx, cipher))]
-pub(crate) async fn runner(
-    mut interconnect: Interconnect,
-    rx: Receiver<UdpRxMessage>,
-    cipher: Cipher,
-    config: Config,
-    udp_socket: RecvHalf,
 ) {
     trace!("UDP receive handle started.");
 

--- a/src/driver/tasks/udp_tx.rs
+++ b/src/driver/tasks/udp_tx.rs
@@ -3,14 +3,8 @@ use crate::constants::*;
 use discortp::discord::MutableKeepalivePacket;
 use flume::Receiver;
 use std::sync::Arc;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{
     net::UdpSocket,
-    time::{timeout_at, Instant},
-};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{
-    net::udp::SendHalf,
     time::{timeout_at, Instant},
 };
 use tracing::{error, instrument, trace};
@@ -19,10 +13,7 @@ struct UdpTx {
     ssrc: u32,
     rx: Receiver<UdpTxMessage>,
 
-    #[cfg(not(feature = "tokio-02-marker"))]
     udp_tx: Arc<UdpSocket>,
-    #[cfg(feature = "tokio-02-marker")]
-    udp_tx: SendHalf,
 }
 
 impl UdpTx {
@@ -62,25 +53,8 @@ impl UdpTx {
     }
 }
 
-#[cfg(not(feature = "tokio-02-marker"))]
 #[instrument(skip(udp_msg_rx))]
 pub(crate) async fn runner(udp_msg_rx: Receiver<UdpTxMessage>, ssrc: u32, udp_tx: Arc<UdpSocket>) {
-    trace!("UDP transmit handle started.");
-
-    let mut txer = UdpTx {
-        ssrc,
-        rx: udp_msg_rx,
-        udp_tx,
-    };
-
-    txer.run().await;
-
-    trace!("UDP transmit handle stopped.");
-}
-
-#[cfg(feature = "tokio-02-marker")]
-#[instrument(skip(udp_msg_rx))]
-pub(crate) async fn runner(udp_msg_rx: Receiver<UdpTxMessage>, ssrc: u32, udp_tx: SendHalf) {
     trace!("UDP transmit handle started.");
 
     let mut txer = UdpTx {

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -11,22 +11,13 @@ use crate::{
     ws::{Error as WsError, ReceiverExt, SenderExt, WsStream},
     ConnectionInfo,
 };
-#[cfg(not(feature = "tokio-02-marker"))]
 use async_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
-#[cfg(feature = "tokio-02-marker")]
-use async_tungstenite_compat::tungstenite::protocol::frame::coding::CloseCode;
 use flume::Receiver;
 use rand::random;
 use std::time::Duration;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{
     select,
     time::{sleep_until, Instant},
-};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{
-    select,
-    time::{delay_until as sleep_until, Instant},
 };
 use tracing::{debug, info, instrument, trace, warn};
 

--- a/src/events/context/data/disconnect.rs
+++ b/src/events/context/data/disconnect.rs
@@ -4,10 +4,7 @@ use crate::{
     model::{CloseCode as VoiceCloseCode, FromPrimitive},
     ws::Error as WsError,
 };
-#[cfg(not(feature = "tokio-02-marker"))]
 use async_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
-#[cfg(feature = "tokio-02-marker")]
-use async_tungstenite_compat::tungstenite::protocol::frame::coding::CloseCode;
 
 /// Voice connection details gathered at termination or failure.
 ///

--- a/src/input/child.rs
+++ b/src/input/child.rs
@@ -4,10 +4,7 @@ use std::{
     mem,
     process::Child,
 };
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::runtime::Handle;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::runtime::Handle;
 use tracing::debug;
 
 /// Handle for a child process which ensures that any subprocesses are properly closed

--- a/src/input/dca.rs
+++ b/src/input/dca.rs
@@ -1,10 +1,7 @@
 use super::{codec::OpusDecoderState, error::DcaError, Codec, Container, Input, Metadata, Reader};
 use serde::Deserialize;
 use std::{ffi::OsStr, mem};
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{fs::File as TokioFile, io::AsyncReadExt};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{fs::File as TokioFile, io::AsyncReadExt};
 
 /// Creates a streamed audio source from a DCA file.
 /// Currently only accepts the [DCA1 format](https://github.com/bwmarrin/dca).

--- a/src/input/ffmpeg_src.rs
+++ b/src/input/ffmpeg_src.rs
@@ -11,10 +11,7 @@ use std::{
     ffi::OsStr,
     process::{Command, Stdio},
 };
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::process::Command as TokioCommand;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::process::Command as TokioCommand;
 use tracing::debug;
 
 /// Opens an audio file through `ffmpeg` and creates an audio source.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -58,10 +58,7 @@ use audiopus::coder::GenericCtl;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use cached::OpusCompressor;
 use error::{Error, Result};
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::runtime::Handle;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::runtime::Handle;
 
 use std::{
     convert::TryFrom,

--- a/src/input/ytdl_src.rs
+++ b/src/input/ytdl_src.rs
@@ -11,10 +11,7 @@ use std::{
     io::{BufRead, BufReader, Read},
     process::{Command, Stdio},
 };
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::{process::Command as TokioCommand, task};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::{process::Command as TokioCommand, task};
 use tracing::trace;
 
 const YOUTUBE_DL_COMMAND: &str = if cfg!(feature = "youtube-dlc") {

--- a/src/join.rs
+++ b/src/join.rs
@@ -16,10 +16,7 @@ use core::{
 };
 use flume::r#async::RecvFut;
 use pin_project::pin_project;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::time::{self, Timeout};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::time::{self, Timeout};
 
 #[cfg(feature = "driver-core")]
 /// Future for a call to [`Call::join`].

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -22,10 +22,7 @@ use serenity::{
     },
 };
 use std::sync::Arc;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::sync::Mutex;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::sync::Mutex;
 use tracing::debug;
 #[cfg(feature = "twilight")]
 use twilight_gateway::Cluster;

--- a/src/tracks/handle.rs
+++ b/src/tracks/handle.rs
@@ -5,10 +5,7 @@ use crate::{
 };
 use flume::Sender;
 use std::{fmt, sync::Arc, time::Duration};
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::sync::RwLock;
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::sync::RwLock;
 use typemap_rev::TypeMap;
 use uuid::Uuid;
 

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,15 +1,7 @@
 use crate::model::Event;
 
 use async_trait::async_trait;
-#[cfg(not(feature = "tokio-02-marker"))]
 use async_tungstenite::{
-    self as tungstenite,
-    tokio::ConnectStream,
-    tungstenite::{error::Error as TungsteniteError, protocol::CloseFrame, Message},
-    WebSocketStream,
-};
-#[cfg(feature = "tokio-02-marker")]
-use async_tungstenite_compat::{
     self as tungstenite,
     tokio::ConnectStream,
     tungstenite::{error::Error as TungsteniteError, protocol::CloseFrame, Message},
@@ -17,10 +9,7 @@ use async_tungstenite_compat::{
 };
 use futures::{SinkExt, StreamExt, TryStreamExt};
 use serde_json::Error as JsonError;
-#[cfg(not(feature = "tokio-02-marker"))]
 use tokio::time::{timeout, Duration};
-#[cfg(feature = "tokio-02-marker")]
-use tokio_compat::time::{timeout, Duration};
 use tracing::instrument;
 
 pub type WsStream = WebSocketStream<ConnectStream>;


### PR DESCRIPTION
> ```
> # Tokio 0.2 Compatibility features
> # These should probably be dropped around the same time as serenity drop them.```
Well... https://github.com/serenity-rs/serenity/pull/1780 got merged so it's time to remove tokio 0.2 support on songbird