### PR TITLE
Bump dependencies and document bumped MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
-symphonia-core = "0.2"
+symphonia-core = "0.5"
 
 [dependencies.async-trait]
 optional = true
@@ -28,7 +28,7 @@ version = "0.1"
 default-features = false
 features = ["tokio-runtime"]
 optional = true
-version = "0.14"
+version = "0.17"
 
 [dependencies.audiopus]
 optional = true
@@ -40,7 +40,7 @@ version = "1"
 
 [dependencies.dashmap]
 optional = true
-version = "4"
+version = "5"
 
 [dependencies.discortp]
 features = ["discord-full"]
@@ -56,7 +56,7 @@ version = "0.3"
 
 [dependencies.parking_lot]
 optional = true
-version = "0.11"
+version = "0.12"
 
 [dependencies.pin-project]
 optional = true
@@ -116,7 +116,7 @@ features = ["v4"]
 
 [dependencies.xsalsa20poly1305]
 optional = true
-version = "0.7"
+version = "0.8"
 features = ["std"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![docs-badge][]][docs] [![build badge]][build] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.49.0+ badge]][rust 1.49.0+ link]
+[![docs-badge][]][docs] [![build badge]][build] [![guild-badge][]][guild] [![crates.io version]][crates.io link] [![rust 1.56.0+ badge]][rust 1.56.0+ link]
 
 # Songbird
 
@@ -69,5 +69,5 @@ Songbird's logo is based upon the copyright-free image ["Black-Capped Chickadee"
 [crates.io link]: https://crates.io/crates/songbird
 [crates.io version]: https://img.shields.io/crates/v/songbird.svg?style=flat-square
 
-[rust 1.49.0+ badge]: https://img.shields.io/badge/rust-1.49.0+-93450a.svg?style=flat-square
-[rust 1.49.0+ link]: https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html
+[rust 1.56.0+ badge]: https://img.shields.io/badge/rust-1.56.0+-93450a.svg?style=flat-square
+[rust 1.56.0+ link]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html


### PR DESCRIPTION
songbird has a load of duplicate dependencies in my codebase and updating them seemed to not break anything. This doesn't actually bump MSRV as that was bumped in the `0.10.12` minor release to 1.56, this PR just updates docs to reflect it.