### PR TITLE
Remove spin_sleep in `Mixer::march_deadline`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,10 +78,6 @@ optional = true
 git = "https://github.com/serenity-rs/serenity"
 branch = "next"
 
-[dependencies.spin_sleep]
-optional = true
-version = "1"
-
 [dependencies.streamcatcher]
 optional = true
 version = "1"
@@ -162,7 +158,6 @@ driver-core = [
     "parking_lot",
     "rand",
     "serenity-voice-model",
-    "spin_sleep",
     "streamcatcher",
     "typemap_rev",
     "url",

--- a/src/driver/tasks/mixer.rs
+++ b/src/driver/tasks/mixer.rs
@@ -399,7 +399,6 @@ impl Mixer {
             return;
         }
 
-        // FIXME: make choice of spin-sleep/imprecise sleep optional in next breaking.
         std::thread::sleep(self.deadline.saturating_duration_since(Instant::now()));
         self.deadline += TIMESTEP_LENGTH;
     }

--- a/src/driver/tasks/mixer.rs
+++ b/src/driver/tasks/mixer.rs
@@ -17,7 +17,6 @@ use discortp::{
 };
 use flume::{Receiver, Sender, TryRecvError};
 use rand::random;
-use spin_sleep::SpinSleeper;
 use std::time::Instant;
 use tokio::runtime::Handle;
 use tracing::{debug, error, instrument};
@@ -38,7 +37,6 @@ pub struct Mixer {
     pub prevent_events: bool,
     pub silence_frames: u8,
     pub skip_sleep: bool,
-    pub sleeper: SpinSleeper,
     pub soft_clip: SoftClip,
     pub tracks: Vec<Track>,
     pub ws: Option<Sender<WsMessage>>,
@@ -95,7 +93,6 @@ impl Mixer {
             prevent_events: false,
             silence_frames: 0,
             skip_sleep: false,
-            sleeper: Default::default(),
             soft_clip,
             tracks,
             ws: None,
@@ -403,8 +400,7 @@ impl Mixer {
         }
 
         // FIXME: make choice of spin-sleep/imprecise sleep optional in next breaking.
-        self.sleeper
-            .sleep(self.deadline.saturating_duration_since(Instant::now()));
+        std::thread::sleep(self.deadline.saturating_duration_since(Instant::now()));
         self.deadline += TIMESTEP_LENGTH;
     }
 


### PR DESCRIPTION
There is no point to be that precise when network latency will ruin it, plus it was using 28% of CPU cycles on my bot. 