### PR TITLE
lazy_static -> once_cell::sync::Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,6 @@ version = "0.10"
 [dependencies.futures]
 version = "0.3"
 
-[dependencies.lazy_static]
-optional = true
-version = "1"
-
 [dependencies.parking_lot]
 optional = true
 version = "0.12"
@@ -191,7 +187,7 @@ driver = [
     "discortp",
     "reqwest",
     "flume",
-    "lazy_static",
+    "once_cell",
     "parking_lot",
     "rand",
     "ringbuf",

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,14 +200,14 @@ impl Config {
 
     /// Sets this `Config`'s symphonia codec registry.
     #[must_use]
-    pub fn codec_registry(mut self, codec_registry: &'static CODEC_REGISTRY) -> Self {
+    pub fn codec_registry(mut self, codec_registry: &'static CodecRegistry) -> Self {
         self.codec_registry = codec_registry;
         self
     }
 
     /// Sets this `Config`'s symphonia format registry/probe set.
     #[must_use]
-    pub fn format_registry(mut self, format_registry: &'static PROBE) -> Self {
+    pub fn format_registry(mut self, format_registry: &'static Probe) -> Self {
         self.format_registry = format_registry;
         self
     }

--- a/src/input/codecs/mod.rs
+++ b/src/input/codecs/mod.rs
@@ -5,30 +5,25 @@ mod opus;
 mod raw;
 
 pub use self::{dca::DcaReader, opus::OpusDecoder, raw::*};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use symphonia::{
     core::{codecs::CodecRegistry, probe::Probe},
     default::*,
 };
 
-lazy_static! {
-    /// Default Symphonia CodecRegistry, including the (audiopus-backed)
-    /// Opus codec.
-    pub static ref CODEC_REGISTRY: CodecRegistry = {
-        let mut registry = CodecRegistry::new();
-        register_enabled_codecs(&mut registry);
-        registry.register_all::<OpusDecoder>();
-        registry
-    };
-}
+/// Default Symphonia [`CodecRegistry`], including the (audiopus-backed) Opus codec.
+pub static CODEC_REGISTRY: Lazy<CodecRegistry> = Lazy::new(|| {
+    let mut registry = CodecRegistry::new();
+    register_enabled_codecs(&mut registry);
+    registry.register_all::<OpusDecoder>();
+    registry
+});
 
-lazy_static! {
-    /// Default Symphonia Probe, including DCA format support.
-    pub static ref PROBE: Probe = {
-        let mut probe = Probe::default();
-        probe.register_all::<DcaReader>();
-        probe.register_all::<RawReader>();
-        register_enabled_formats(&mut probe);
-        probe
-    };
-}
+/// Default Symphonia Probe, including DCA format support.
+pub static PROBE: Lazy<Probe> = Lazy::new(|| {
+    let mut probe = Probe::default();
+    probe.register_all::<DcaReader>();
+    probe.register_all::<RawReader>();
+    register_enabled_formats(&mut probe);
+    probe
+});


### PR DESCRIPTION
This reduces macro magic, and once_cell was already depended on anyway