### PR TITLE
Chore: Rework crate features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
             features: driver rustls
             dont-test: true
           - name: gateway only
-            features: serenity-rustls
+            features: gateway serenity rustls
             dont-test: true
           - name: simd json
-            features: simd-json serenity-rustls driver gateway serenity/simd_json
+            features: simd-json serenity rustls driver gateway serenity?/simd_json
             rustflags: -C target-cpu=native
             dont-test: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,155 +10,67 @@ license = "ISC"
 name = "songbird"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/songbird.git"
-version = "0.2.2"
 rust-version = "1.61"
+version = "0.3.0"
 
 [dependencies]
+async-trait = { optional = true, version = "0.1" }
+audiopus = { optional = true, version = "0.3.0-rc.0" }
+byteorder = { optional = true, version = "1" }
+dashmap = { optional = true, version = "5" }
 derivative = "2"
+discortp = { features = ["discord-full"], optional = true, version = "0.5" }
+flume = { optional = true, version = "0.10" }
+futures = "0.3"
+once_cell = { optional = true, version = "1" }
+parking_lot = { optional = true, version = "0.12" }
 pin-project = "1"
+rand = { optional = true, version = "0.8" }
+reqwest = { default-features = false, features = ["stream"], optional = true, version = "0.11" }
+ringbuf = { optional = true, version = "0.2" }
+rubato = { optional = true, version = "0.12" }
+rusty_pool = { optional = true, version = "0.7" }
 serde = { version = "1", features = ["derive"] }
+serde-aux = { default-features = false, optional = true, version = "3"}
+simd-json = { features = ["serde_impl"], optional = true, version = "0.6.0" }
 serde_json = "1"
+streamcatcher = { optional = true, version = "1" }
+tokio = { default-features = false, optional = true, version = "1.0" }
+tokio-tungstenite = { optional = true, version = "0.17" }
+tokio-util = { features = ["io"], optional = true, version = "0.7" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
-
-[dependencies.async-trait]
-optional = true
-version = "0.1"
-
-[dependencies.audiopus]
-optional = true
-version = "0.3.0-rc.0"
-
-[dependencies.byteorder]
-optional = true
-version = "1"
-
-[dependencies.dashmap]
-optional = true
-version = "5"
-
-[dependencies.discortp]
-features = ["discord-full"]
-optional = true
-version = "0.5"
-
-[dependencies.flume]
-optional = true
-version = "0.10"
-
-[dependencies.futures]
-version = "0.3"
-
-[dependencies.once_cell]
-version = "1"
-optional = true
-
-[dependencies.parking_lot]
-optional = true
-version = "0.12"
-
-[dependencies.rand]
-optional = true
-version = "0.8"
-
-[dependencies.reqwest]
-optional = true
-default-features = false
-features = ["stream"]
-version = "0.11"
-
-[dependencies.ringbuf]
-optional = true
-version = "0.2"
-
-[dependencies.rubato]
-optional = true
-version = "0.12"
-
-[dependencies.rusty_pool]
-optional = true
-version = "0.7"
-
-[dependencies.serde-aux]
-default-features = false
-optional = true
-version = "3"
+twilight-gateway = { default-features = false, optional = true, version = "0.12.0" }
+twilight-model = { default-features = false, optional = true, version = "0.12.0" }
+typemap_rev = { optional = true, version = "0.1" }
+url = { optional = true, version = "2" }
+uuid = { features = ["v4"], optional = true, version = "1" }
+xsalsa20poly1305 = { features = ["std"], optional = true, version = "0.8" }
 
 [dependencies.serenity]
-optional = true
+branch = "next"
 default-features = false
 features = ["voice", "gateway"]
 git = "https://github.com/serenity-rs/serenity"
-branch = "next"
+optional = true
 
 [dependencies.serenity-voice-model]
-optional = true
-git = "https://github.com/serenity-rs/serenity"
 branch = "next"
-
-[dependencies.simd-json]
+git = "https://github.com/serenity-rs/serenity"
 optional = true
-features = ["serde_impl"]
-version = "0.6.0"
-
-[dependencies.streamcatcher]
-optional = true
-version = "1"
 
 [dependencies.symphonia]
-optional = true
-default-features = false
-version = "0.5"
-git = "https://github.com/FelixMcFelix/Symphonia"
 branch = "songbird-fixes"
+git = "https://github.com/FelixMcFelix/Symphonia"
+default-features = false
+optional = true
+version = "0.5"
 
 [dependencies.symphonia-core]
+branch = "songbird-fixes"
+git = "https://github.com/FelixMcFelix/Symphonia"
 optional = true
 version = "0.5"
-git = "https://github.com/FelixMcFelix/Symphonia"
-branch = "songbird-fixes"
-
-[dependencies.tokio]
-optional = true
-version = "1.0"
-default-features = false
-
-[dependencies.tokio-tungstenite]
-optional = true
-version = "0.17"
-
-[dependencies.tokio-util]
-optional = true
-version = "0.7"
-features = ["io"]
-
-[dependencies.twilight-gateway]
-optional = true
-version = "0.12.0"
-default-features = false
-
-[dependencies.twilight-model]
-optional = true
-version = "0.12.0"
-default-features = false
-
-[dependencies.typemap_rev]
-optional = true
-version = "0.1"
-
-[dependencies.url]
-optional = true
-version = "2"
-
-[dependencies.uuid]
-optional = true
-version = "1"
-features = ["v4"]
-
-[dependencies.xsalsa20poly1305]
-optional = true
-version = "0.8"
-features = ["std"]
 
 [dev-dependencies]
 criterion = "0.3"
@@ -170,72 +82,74 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 [features]
 # Core features
 default = [
-    "serenity-rustls",
     "driver",
     "gateway",
+    "rustls",
+    "serenity",
 ]
 gateway = [
-    "dashmap",
-    "flume",
-    "once_cell",
-    "parking_lot",
-    "tokio/sync",
-    "tokio/time",
+    "dep:async-trait",
+    "dep:dashmap",
+    "dep:flume",
+    "dep:once_cell",
+    "dep:parking_lot",
+    "dep:tokio",
+    "tokio?/sync",
+    "tokio?/time",
 ]
 driver = [
-    "async-trait",
-    "audiopus",
-    "byteorder",
-    "discortp",
-    "reqwest",
-    "flume",
-    "once_cell",
-    "parking_lot",
-    "rand",
-    "ringbuf",
-    "rubato",
-    "serde-aux",
-    "serenity-voice-model",
-    "streamcatcher",
-    "symphonia",
-    "symphonia-core",
-    "rusty_pool",
-    "tokio/fs",
-    "tokio/io-util",
-    "tokio/macros",
-    "tokio/net",
-    "tokio/process",
-    "tokio/rt",
-    "tokio/sync",
-    "tokio/time",
-    "tokio-tungstenite",
-    "tokio-util",
-    "typemap_rev",
-    "url",
-    "uuid",
-    "xsalsa20poly1305",
+    "dep:async-trait",
+    "dep:audiopus",
+    "dep:byteorder",
+    "dep:discortp",
+    "dep:reqwest",
+    "dep:flume",
+    "dep:once_cell",
+    "dep:parking_lot",
+    "dep:rand",
+    "dep:ringbuf",
+    "dep:rubato",
+    "dep:rusty_pool",
+    "dep:serde-aux",
+    "dep:serenity-voice-model",
+    "dep:streamcatcher",
+    "dep:symphonia",
+    "dep:symphonia-core",
+    "dep:tokio",
+    "dep:tokio-tungstenite",
+    "dep:tokio-util",
+    "dep:typemap_rev",
+    "dep:url",
+    "dep:uuid",
+    "dep:xsalsa20poly1305",
+    "tokio?/fs",
+    "tokio?/io-util",
+    "tokio?/macros",
+    "tokio?/net",
+    "tokio?/process",
+    "tokio?/rt",
+    "tokio?/sync",
+    "tokio?/time",
 ]
-rustls = ["tokio-tungstenite/rustls-tls-webpki-roots", "reqwest/rustls-tls", "rustls-marker"]
-native = ["tokio-tungstenite/native-tls", "native-marker", "reqwest/native-tls"]
-serenity-rustls = ["serenity/rustls_backend", "rustls", "gateway", "serenity-deps"]
-serenity-native = ["serenity/native_tls_backend", "native", "gateway", "serenity-deps"]
-twilight-rustls = ["twilight", "twilight-gateway/rustls-native-roots", "rustls", "gateway"]
-twilight-native = ["twilight", "twilight-gateway/native", "native", "gateway"]
-twilight = ["twilight-model"]
-zlib-simd = ["twilight-gateway/zlib-simd"]
-zlib-stock = ["twilight-gateway/zlib-stock"]
-serenity-deps = ["async-trait"]
-
-simdjson = []
-
-rustls-marker = []
-native-marker = []
+rustls = [
+    "reqwest?/rustls-tls",
+    "serenity?/rustls_backend",
+    "tokio-tungstenite?/rustls-tls-webpki-roots",
+    "twilight-gateway?/rustls-native-roots",
+]
+native = [
+    "reqwest?/native-tls",
+    "serenity?/native_tls_backend",
+    "tokio-tungstenite?/native-tls",
+    "twilight-gateway?/native",
+]
+twilight = ["dep:twilight-gateway","dep:twilight-model"]
 
 # Behaviour altering features.
 builtin-queue = []
 
 # Used for docgen/testing/benchmarking.
-full-doc = ["default", "twilight-rustls", "builtin-queue", "zlib-stock"]
+full-doc = ["default", "twilight", "builtin-queue"]
 internals = []
 
 [[bench]]
@@ -252,3 +166,4 @@ harness = false
 
 [package.metadata.docs.rs]
 features = ["full-doc"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,7 +9,7 @@ args = ["build", "--features", "full-doc"]
 dependencies = ["format"]
 
 [tasks.build-simd]
-args = ["build", "--features", "full-doc,simd-json,serenity/simd_json,twilight-gateway/simd-json"]
+args = ["build", "--features", "full-doc,simd-json,serenity?/simd_json,twilight-gateway?/simd-json"]
 command = "cargo"
 dependencies = ["format"]
 env = { "RUSTFLAGS" = "-C target-cpu=native" }
@@ -20,7 +20,7 @@ command = "cargo"
 dependencies = ["format"]
 
 [tasks.build-gateway]
-args = ["build", "--no-default-features", "--features", "serenity-rustls"]
+args = ["build", "--no-default-features", "--features", "gateway,serenity,rustls"]
 command = "cargo"
 dependencies = ["format"]
 
@@ -44,7 +44,7 @@ dependencies = ["format"]
 args = ["test", "--features", "full-doc"]
 
 [tasks.test-simd]
-args = ["test", "--features", "full-doc,simd-json,serenity/simd_json,twilight-gateway/simd-json"]
+args = ["test", "--features", "full-doc,simd-json,serenity?/simd_json,twilight-gateway?/simd-json"]
 command = "cargo"
 env = { "RUSTFLAGS" = "-C target-cpu=native" }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Songbird is an async, cross-library compatible voice system for Discord, written in Rust.
 The library offers:
  * A standalone gateway frontend compatible with [serenity] and [twilight] using the
- `"gateway"` and `"[serenity/twilight]-[rustls/native]"` features. You can even run
+ `"gateway"` and `"[serenity/twilight]"` plus `"[rustls/native]"` features. You can even run
  driverless, to help manage your [lavalink] sessions.
  * A standalone driver for voice calls, via the `"driver"` feature. If you can create
  a `ConnectionInfo` using any other gateway, or language for your bot, then you

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,4 @@
-#[cfg(all(
-    feature = "driver",
-    not(any(feature = "rustls-marker", feature = "native-marker"))
-))]
+#[cfg(all(feature = "driver", not(any(feature = "rustls", feature = "native"))))]
 compile_error!(
     "You have the `driver` feature enabled: \
     either the `rustls` or `native` feature must be
@@ -10,17 +7,6 @@ compile_error!(
     - `native` uses SChannel on Windows, Secure Transport on macOS, \
     and OpenSSL on other platforms.\n\
     If you are unsure, go with `rustls`."
-);
-
-#[cfg(all(
-    feature = "twilight",
-    not(any(feature = "zlib-simd", feature = "zlib-stock"))
-))]
-compile_error!(
-    "Twilight requires you to specify a zlib backend: \
-    either the `zlib-simd` or `zlib-stock` feature must be
-    selected.\n\
-    If you are unsure, go with `zlib-stock`."
 );
 
 fn main() {}

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -18,7 +18,7 @@ twilight-standby = "0.12"
 [dependencies.songbird]
 default-features = false
 path = "../.."
-features = ["driver", "twilight-rustls", "zlib-stock"]
+features = ["driver", "twilight", "rustls"]
 
 [dependencies.symphonia]
 version = "0.5"

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -18,7 +18,7 @@ twilight-standby = "0.12"
 [dependencies.songbird]
 default-features = false
 path = "../.."
-features = ["driver", "twilight", "rustls"]
+features = ["driver", "gateway", "twilight", "rustls"]
 
 [dependencies.symphonia]
 version = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
     html_logo_url = "https://raw.githubusercontent.com/serenity-rs/songbird/current/songbird.png",
     html_favicon_url = "https://raw.githubusercontent.com/serenity-rs/songbird/current/songbird-ico.png"
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 //! ![project logo][logo]
@@ -9,7 +10,7 @@
 //! Songbird is an async, cross-library compatible voice system for Discord, written in Rust.
 //! The library offers:
 //!  * A standalone gateway frontend compatible with [serenity] and [twilight] using the
-//!  `"gateway"` and `"[serenity/twilight]-[rustls/native]"` features. You can even run
+//!  `"gateway"` and `"[serenity/twilight]"` plus `"[rustls/native]"` features. You can even run
 //!  driverless, to help manage your [lavalink] sessions.
 //!  * A standalone driver for voice calls, via the `"driver"` feature. If you can create
 //!  a [`ConnectionInfo`] using any other gateway, or language for your bot, then you

--- a/src/serenity.rs
+++ b/src/serenity.rs
@@ -1,5 +1,5 @@
 //! Compatability and convenience methods for working with [serenity].
-//! Requires the `"serenity-rustls"` or `"serenity-native"` features.
+//! Requires the `"serenity"` feature.
 //!
 //! [serenity]: https://crates.io/crates/serenity/0.9.0-rc.2
 


### PR DESCRIPTION
All dependencies have been moved to the new "dep:x" and "x?/feature" syntax to remove the bloat from the docs.rs/crates.io/lib.rs feature panes.

Accordingly, this lets us break "rustls" and "native" out from annoying hybrids like "serenity-rustls" or "twilight-native" -- specify your library and your bacnend, and it should just work.

The complete list of features is now: driver, gateway, serenity, twilight, rustls, native, builtin-queue, simd-json, internals (plus "default" and "full-doc").