### PR TITLE
Driver: Prune `SsrcState` after timeout/disconnect

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,13 @@ pub struct Config {
     /// [user speaking events]: crate::events::CoreEvent::SpeakingUpdate
     pub decode_mode: DecodeMode,
 
+    #[cfg(all(feature = "driver", feature = "receive"))]
+    /// Configures the amount of time after a user/SSRC is inactive before their decoder state
+    /// should be removed.
+    ///
+    /// Defaults to 1 minute.
+    pub decode_state_timeout: Duration,
+
     #[cfg(feature = "gateway")]
     /// Configures the amount of time to wait for Discord to reply with connection information
     /// if [`Call::join`]/[`join_gateway`] are used.
@@ -155,6 +162,8 @@ impl Default for Config {
             crypto_mode: CryptoMode::Normal,
             #[cfg(all(feature = "driver", feature = "receive"))]
             decode_mode: DecodeMode::Decrypt,
+            #[cfg(all(feature = "driver", feature = "receive"))]
+            decode_state_timeout: Duration::from_secs(60),
             #[cfg(feature = "gateway")]
             gateway_timeout: Some(Duration::from_secs(10)),
             #[cfg(feature = "driver")]
@@ -195,6 +204,14 @@ impl Config {
     #[must_use]
     pub fn decode_mode(mut self, decode_mode: DecodeMode) -> Self {
         self.decode_mode = decode_mode;
+        self
+    }
+
+    #[cfg(feature = "receive")]
+    /// Sets this `Config`'s received packet decoder cleanup timer.
+    #[must_use]
+    pub fn decode_state_timeout(mut self, decode_state_timeout: Duration) -> Self {
+        self.decode_state_timeout = decode_state_timeout;
         self
     }
 

--- a/src/driver/tasks/message/udp_rx.rs
+++ b/src/driver/tasks/message/udp_rx.rs
@@ -2,8 +2,16 @@
 
 use super::Interconnect;
 use crate::driver::Config;
+use dashmap::{DashMap, DashSet};
+use serenity_voice_model::id::UserId;
 
 pub enum UdpRxMessage {
     SetConfig(Config),
     ReplaceInterconnect(Interconnect),
+}
+
+#[derive(Debug, Default)]
+pub struct SsrcTracker {
+    pub disconnected_users: DashSet<UserId>,
+    pub user_ssrc_map: DashMap<UserId, u32>,
 }


### PR DESCRIPTION
`SsrcState` objects are created on a per-user basis when "receive" is enabled, but were previously never destroyed. This PR adds some shared dashmaps for the WS task to communicate SSRC-to-ID mappings to the UDP Rx task, as well as any disconnections. Additionally, decoder state is pruned a default 1 minute after a user last speaks.

This was tested using `cargo make ready` and via `examples/serenity/voice_receive/`.

Closes #133