### PR TITLE
Avoid spawning a disposal thread per driver

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,15 +2,13 @@
 use crate::driver::DecodeMode;
 #[cfg(feature = "driver")]
 use crate::{
-    driver::{retry::Retry, tasks::disposal, tasks::message::DisposalMessage, CryptoMode, MixMode},
+    driver::{retry::Retry, tasks::disposal::DisposalThread, CryptoMode, MixMode},
     input::codecs::*,
 };
 
 #[cfg(test)]
 use crate::driver::test_config::*;
 
-#[cfg(feature = "driver")]
-use flume::Sender;
 #[cfg(feature = "driver")]
 use symphonia::core::{codecs::CodecRegistry, probe::Probe};
 
@@ -154,7 +152,7 @@ pub struct Config {
     /// Note: When using [`Songbird`] this is overwritten automatically by it's disposal thread.
     ///
     /// [`Songbird`]: crate::Songbird
-    pub disposer: Option<Sender<DisposalMessage>>,
+    pub disposer: Option<DisposalThread>,
 
     // Test only attributes
     #[cfg(feature = "driver")]
@@ -280,7 +278,7 @@ impl Config {
 
     /// Sets this `Config`'s channel for sending disposal messages.
     #[must_use]
-    pub fn disposer(mut self, disposer: Sender<DisposalMessage>) -> Self {
+    pub fn disposer(mut self, disposer: DisposalThread) -> Self {
         self.disposer = Some(disposer);
         self
     }
@@ -291,7 +289,7 @@ impl Config {
         if self.disposer.is_some() {
             self
         } else {
-            self.disposer(disposal::run())
+            self.disposer(DisposalThread::run())
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -303,6 +303,13 @@ impl Config {
     }
 }
 
+#[cfg(not(feature = "driver"))]
+impl Config {
+    pub(crate) fn initialise_disposer(self) -> Self {
+        self
+    }
+}
+
 // Test only attributes
 #[cfg(all(test, feature = "driver"))]
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ pub struct Config {
     /// If not set, a thread will be spawned to perform this, but it is recommended to create
     /// a long running thread instead of relying on a per-driver thread.
     ///
-    /// Note: When using [`Songbird`] this is overwritten automatically by it's disposal thread.
+    /// Note: When using [`Songbird`] this is overwritten automatically by its disposal thread.
     ///
     /// [`Songbird`]: crate::Songbird
     pub disposer: Option<DisposalThread>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 use crate::driver::DecodeMode;
 #[cfg(feature = "driver")]
 use crate::{
-    driver::{retry::Retry, CryptoMode, MixMode, tasks::message::DisposalMessage, tasks::disposal},
+    driver::{retry::Retry, tasks::disposal, tasks::message::DisposalMessage, CryptoMode, MixMode},
     input::codecs::*,
 };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,7 +154,7 @@ pub struct Config {
     /// Note: When using [`Songbird`] this is overwritten automatically by it's disposal thread.
     ///
     /// [`Songbird`]: crate::Songbird
-    pub disposor: Option<Sender<DisposalMessage>>,
+    pub disposer: Option<Sender<DisposalMessage>>,
 
     // Test only attributes
     #[cfg(feature = "driver")]
@@ -193,7 +193,7 @@ impl Default for Config {
             #[cfg(feature = "driver")]
             format_registry: &PROBE,
             #[cfg(feature = "driver")]
-            disposor: None,
+            disposer: None,
             #[cfg(feature = "driver")]
             #[cfg(test)]
             tick_style: TickStyle::Timed,
@@ -280,18 +280,18 @@ impl Config {
 
     /// Sets this `Config`'s channel for sending disposal messages.
     #[must_use]
-    pub fn disposor(mut self, disposor: Sender<DisposalMessage>) -> Self {
-        self.disposor = Some(disposor);
+    pub fn disposer(mut self, disposer: Sender<DisposalMessage>) -> Self {
+        self.disposer = Some(disposer);
         self
     }
 
-    /// Ensures a global disposor has been set, initializing one if not.
+    /// Ensures a global disposer has been set, initializing one if not.
     #[must_use]
-    pub(crate) fn initialise_disposor(self) -> Self {
-        if self.disposor.is_some() {
+    pub(crate) fn initialise_disposer(self) -> Self {
+        if self.disposer.is_some() {
             self
         } else {
-            self.disposor(disposal::run())
+            self.disposer(disposal::run())
         }
     }
 

--- a/src/driver/tasks/disposal.rs
+++ b/src/driver/tasks/disposal.rs
@@ -1,6 +1,17 @@
 use super::message::*;
-use flume::Receiver;
-use tracing::instrument;
+use flume::{Receiver, Sender};
+use tracing::{instrument, trace};
+
+pub(crate) fn run() -> Sender<DisposalMessage> {
+    let (mix_tx, mix_rx) = flume::unbounded();
+    std::thread::spawn(move || {
+        trace!("Disposal thread started.");
+        runner(mix_rx);
+        trace!("Disposal thread finished.");
+    });
+
+    mix_tx
+}
 
 /// The mixer's disposal thread is also synchronous, due to tracks,
 /// inputs, etc. being based on synchronous I/O.

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -126,14 +126,11 @@ impl Mixer {
         let tracks = Vec::with_capacity(1.max(config.preallocated_tracks));
         let track_handles = Vec::with_capacity(1.max(config.preallocated_tracks));
 
-        // Create an object disposal thread here.
-        let (disposer, disposal_rx) = flume::unbounded();
-        std::thread::spawn(move || disposal::runner(disposal_rx));
-
         let thread_pool = BlockyTaskPool::new(async_handle);
 
         let symph_layout = config.mix_mode.symph_layout();
 
+        let disposer = config.disposor.clone().unwrap_or_else(disposal::run);
         let config = config.into();
 
         let sample_buffer = SampleBuffer::<f32>::new(

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -130,7 +130,7 @@ impl Mixer {
 
         let symph_layout = config.mix_mode.symph_layout();
 
-        let disposer = config.disposor.clone().unwrap_or_else(disposal::run);
+        let disposer = config.disposer.clone().unwrap_or_else(disposal::run);
         let config = config.into();
 
         let sample_buffer = SampleBuffer::<f32>::new(

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -76,7 +76,7 @@ impl Songbird {
             client_data: OnceCell::new(),
             calls: DashMap::new(),
             sharder: Sharder::Serenity(SerenitySharder::default()),
-            config: config.initialise_disposor().into(),
+            config: config.initialise_disposer().into(),
         })
     }
 
@@ -114,7 +114,7 @@ impl Songbird {
             }),
             calls: DashMap::new(),
             sharder: Sharder::TwilightCluster(cluster),
-            config: config.initialise_disposor().into(),
+            config: config.initialise_disposer().into(),
         }
     }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -49,7 +49,7 @@ pub struct Songbird {
     client_data: OnceCell<ClientData>,
     calls: DashMap<GuildId, Arc<Mutex<Call>>>,
     sharder: Sharder,
-    config: PRwLock<Option<Config>>,
+    config: PRwLock<Config>,
 }
 
 impl Songbird {
@@ -76,7 +76,7 @@ impl Songbird {
             client_data: OnceCell::new(),
             calls: DashMap::new(),
             sharder: Sharder::Serenity(SerenitySharder::default()),
-            config: Some(config).into(),
+            config: config.initialise_disposor().into(),
         })
     }
 
@@ -114,7 +114,7 @@ impl Songbird {
             }),
             calls: DashMap::new(),
             sharder: Sharder::TwilightCluster(cluster),
-            config: Some(config).into(),
+            config: config.initialise_disposor().into(),
         }
     }
 
@@ -176,7 +176,7 @@ impl Songbird {
                         guild_id,
                         shard_handle,
                         info.user_id,
-                        self.config.read().clone().unwrap_or_default(),
+                        self.config.read().clone(),
                     );
 
                     Arc::new(Mutex::new(call))
@@ -193,7 +193,7 @@ impl Songbird {
     /// Requires the `"driver"` feature.
     pub fn set_config(&self, new_config: Config) {
         let mut config = self.config.write();
-        *config = Some(new_config);
+        *config = new_config;
     }
 
     #[cfg(feature = "driver")]


### PR DESCRIPTION
*This is part of my work to reduce the thread count of Songbird, to majorly improve performance and reduce load on the scheduler.*

Adds a new field to Config, `disposer`, an `Option<Sender<DisposalMessage>>` responsible for dropping the `DisposalMessage` on a separate thread.

If this is not set, and the `Config` is passed into `manager::Songbird`, a thread is spawned for this purpose (which previously was spawned per driver). 
If this is not set, and the `Config` is passed directly into `Driver` or `Call`, a thread is spawned locally, which is the current behavior as there is no where to store the `Sender`.

This `disposer` is then used in `Driver` as previously, to run possibly blocking destructors (which should only block the disposal thread). I cannot see this disposal thread getting overloaded, but if it is the `DisposalMessage`s will simply be queued in the flume channel until it can be dropped.
