### PR TITLE
Fix wrong docstring for Track::volume

### DIFF
--- a/src/tracks/mod.rs
+++ b/src/tracks/mod.rs
@@ -184,7 +184,7 @@ impl Track {
         self
     }
 
-    /// Returns the current playback position.
+    /// Returns the current volume.
     pub fn volume(&self) -> f32 {
         self.volume
     }


### PR DESCRIPTION
This is a very minor issue, but I found a wrong docstring for Track::volume. Sending the fix.