### PR TITLE
Fixed position reporting bug

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -376,6 +376,7 @@ impl Seek for Input {
                 SeekFrom::Start(self.container.input_start() as u64),
             )?;
 
+            self.pos = 0;
             self.cheap_consume(target)
         })
         .map(|_| self.pos as u64)


### PR DESCRIPTION
Without this line resetting the position here, two things happen

- When seeking backwards in a track, the reported position will just add the time you seek to itself
- When a track loops, it does not reset it's position to 0 and will continue to overflow from it's end time