### PR TITLE
Input: Fix high CPU use when initialising long files over HTTP

### DIFF
--- a/src/input/adapters/async_adapter.rs
+++ b/src/input/adapters/async_adapter.rs
@@ -323,6 +323,7 @@ enum AdapterResponse {
     ReadOccurred,
 }
 
+#[derive(Copy, Clone)]
 enum Operation {
     Read { block: bool },
     Seek,
@@ -330,14 +331,14 @@ enum Operation {
 }
 
 impl Operation {
-    fn will_block(&self) -> bool {
+    fn will_block(self) -> bool {
         match self {
-            Self::Read { block } => *block,
+            Self::Read { block } => block,
             _ => true,
         }
     }
 
-    fn expected_msg(&self, msg: &AdapterResponse) -> bool {
+    fn expected_msg(self, msg: &AdapterResponse) -> bool {
         match self {
             Self::Read { .. } => matches!(
                 msg,


### PR DESCRIPTION
Fixes the possibility of a spinlock while reading bytes from an async->sync adapter. This case can be observed with long (e.g., 10 hours of silence) videos which seem to be served slower than we would like to parse their headers.

The fix moves most communication to blocking: `read` calls first parse all messages form the async context in a non-blocking way, then swap to blocking if no bytes are available.

Tested using `cargo make ready` and "examples/serenity/voice" against the URL https://www.youtube.com/watch?v=g4mHPeMGTJM.