### PR TITLE
Input: Pass `--no-playlist` for `YoutubeDl`

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -87,6 +87,13 @@ pub mod test_data {
     /// Referenced under CC BY-NC-SA 3.0 -- https://creativecommons.org/licenses/by-nc-sa/3.0/
     pub const YTDL_TARGET: &str = "https://cloudkicker.bandcamp.com/track/94-days";
 
+    /// URL for a source that has both a playlist and a music video,
+    /// which YTDL should extract.
+    ///
+    /// Referenced under CC BY-NC-SA 3.0 -- https://creativecommons.org/licenses/by/3.0/
+    pub const YTDL_PLAYLIST_TARGET: &str =
+        "https://www.youtube.com/watch?v=hAl_mSCEe5w&list=RDhAl_mSCEe5w&start_radio=1";
+
     /// URL for a source which can be read via an Http Request.
     ///
     /// Referenced under CC BY-NC-SA 3.0 -- https://creativecommons.org/licenses/by-nc-sa/3.0/

--- a/src/input/input_tests.rs
+++ b/src/input/input_tests.rs
@@ -60,7 +60,7 @@ pub async fn track_plays_base<T, F>(
 
     // post-conditions:
     // 1) track produces a packet.
-    // 2) that packet is passthrough.
+    // 2) that packet is passthrough/mixed when we expect them to.
     let pkt = t_handle.recv_async().await;
     let pkt = pkt.raw().unwrap();
 

--- a/src/input/metadata/ytdl.rs
+++ b/src/input/metadata/ytdl.rs
@@ -3,7 +3,7 @@ use crate::constants::SAMPLE_RATE_RAW;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Output {
     pub artist: Option<String>,
     pub album: Option<String>,

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -57,7 +57,13 @@ impl YoutubeDl {
     }
 
     async fn query(&mut self) -> Result<Output, AudioStreamError> {
-        let ytdl_args = ["-j", &self.url, "-f", "ba[abr>0][vcodec=none]/best"];
+        let ytdl_args = [
+            "-j",
+            &self.url,
+            "-f",
+            "ba[abr>0][vcodec=none]/best",
+            "--no-playlist",
+        ];
 
         let mut output = Command::new(self.program)
             .args(ytdl_args)
@@ -144,12 +150,20 @@ mod tests {
     use reqwest::Client;
 
     use super::*;
-    use crate::{constants::test_data::YTDL_TARGET, input::input_tests::*};
+    use crate::constants::test_data::*;
+    use crate::input::input_tests::*;
 
     #[tokio::test]
     #[ntest::timeout(20_000)]
     async fn ytdl_track_plays() {
         track_plays_mixed(|| YoutubeDl::new(Client::new(), YTDL_TARGET.into())).await;
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(20_000)]
+    async fn ytdl_page_with_playlist_plays() {
+        track_plays_passthrough(|| YoutubeDl::new(Client::new(), YTDL_PLAYLIST_TARGET.into()))
+            .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
If a link such as [this](https://www.youtube.com/watch?v=ygY2qObZv24&list=RDygY2qObZv24) is passed to `YoutubeDl` without the option, it would cause a deadlock in my bot.

There were many videos where it produced a `Silent` packet first instead of mixed or passthrough. The URL I added was one that produced a passthrough packet so I used that. Please let me know if this is wrong.