### PR TITLE
Chore(workflows): Update checkout action from v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install toolchain
         id: tc
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install toolchain
         id: tc
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install toolchain
         id: tc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install toolchain
         id: tc


### PR DESCRIPTION
This change was done as the v2 version still used the node v12 runtime. This runtime is deprecated by github. There are no other breaking changes done by the action. With the update to v3 now node v16 is used as runtime for the action.

You can read more about the changes from v2 to v3 here: https://github.com/actions/checkout/releases/tag/v3.0.0

Thanks for the cool project. I really enjoy serenity and songbird! :heart: 

There are a few other deprecated actions in the workflows. I plan to update these as well in other PRs. 