### PR TITLE
Chore(docs): Update rust setup action and cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,32 +10,27 @@ jobs:
   docs:
     name: Publish docs
     runs-on: ubuntu-latest
+    permissions:
+      # peaceiris/actions-gh-pages requires write permission
+      # as it pushes a new commit to the gh-pages branch
+      contents: write
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
       - name: Install toolchain
-        id: tc
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libopus-dev
-
-      - name: Setup cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/debug
-          key: ${{ runner.os }}-gh-pages-${{ steps.tc.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Build docs
         env:


### PR DESCRIPTION
This PR changes the following things in the docs workflow:
- Move from the deprecated actions-rs action to the maintained alternative of dtolnay https://github.com/dtolnay/rust-toolchain
- Instead of manually defining the cache paths and the cache keys, I moved to an action that handles this for us: https://github.com/Swatinem/rust-cache
- As github decided at some point that the generated `GITHUB_TOKEN` secret will only have read-only permissions (for new repos), unless you tell them to be different, I added the `permissions` key to the job. This will not affect this repository, but will affect e.g. new forks (the workflow will not throw an permissions error any more - Read more here: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/ )