### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/driver/scheduler/mod.rs
+++ b/src/driver/scheduler/mod.rs
@@ -24,7 +24,7 @@ const RESCHEDULE_THRESHOLD: u64 = ((TIMESTEP_LENGTH.subsec_nanos() as u64) * 9) 
 
 const DEFAULT_MIXERS_PER_THREAD: NonZeroUsize = match NonZeroUsize::new(16) {
     Some(v) => v,
-    None => [][0],
+    None => unreachable!(),
 };
 
 /// The default shared scheduler instance.

--- a/src/driver/tasks/events.rs
+++ b/src/driver/tasks/events.rs
@@ -6,8 +6,8 @@ use crate::{
 use flume::Receiver;
 use tracing::{debug, info, instrument, trace};
 
-#[instrument(skip(_interconnect, evt_rx))]
-pub(crate) async fn runner(_interconnect: Interconnect, evt_rx: Receiver<EventMessage>) {
+#[instrument(skip(evt_rx))]
+pub(crate) async fn runner(evt_rx: Receiver<EventMessage>) {
     let mut global = GlobalEvents::default();
 
     let mut events: Vec<EventStore> = vec![];

--- a/src/driver/tasks/message/mod.rs
+++ b/src/driver/tasks/message/mod.rs
@@ -40,10 +40,9 @@ impl Interconnect {
 
         self.events = evt_tx;
 
-        let ic = self.clone();
         spawn(async move {
             trace!("Event processor restarted.");
-            super::events::runner(ic, evt_rx).await;
+            super::events::runner(evt_rx).await;
             trace!("Event processor finished.");
         });
 

--- a/src/driver/tasks/mixer/mix_logic.rs
+++ b/src/driver/tasks/mixer/mix_logic.rs
@@ -259,7 +259,7 @@ pub fn mix_symph_indiv(
 
 #[inline]
 fn mix_over_ref(
-    source: &AudioBufferRef,
+    source: &AudioBufferRef<'_>,
     target: &mut AudioBuffer<f32>,
     source_pos: usize,
     dest_pos: usize,
@@ -397,7 +397,7 @@ fn mix_resampled(
 
 #[inline]
 pub(crate) fn copy_into_resampler(
-    source: &AudioBufferRef,
+    source: &AudioBufferRef<'_>,
     target: &mut AudioBuffer<f32>,
     source_pos: usize,
     dest_pos: usize,

--- a/src/driver/tasks/mixer/state.rs
+++ b/src/driver/tasks/mixer/state.rs
@@ -15,7 +15,7 @@ pub enum InputState {
 }
 
 impl InputState {
-    pub fn metadata(&mut self) -> Option<Metadata> {
+    pub fn metadata(&mut self) -> Option<Metadata<'_>> {
         if let Self::Ready(parsed, _) = self {
             Some(parsed.into())
         } else {

--- a/src/input/adapters/cached/util.rs
+++ b/src/input/adapters/cached/util.rs
@@ -335,7 +335,7 @@ impl MediaSource for ToAudioBytes {
 
 #[inline]
 fn write_out(
-    source: &AudioBufferRef,
+    source: &AudioBufferRef<'_>,
     target: &mut [u8],
     source_pos: &mut Range<usize>,
     spillover: &mut Vec<f32>,

--- a/src/input/codecs/opus.rs
+++ b/src/input/codecs/opus.rs
@@ -133,7 +133,7 @@ impl Decoder for OpusDecoder {
         FinalizeResult::default()
     }
 
-    fn last_decoded(&self) -> AudioBufferRef {
+    fn last_decoded(&self) -> AudioBufferRef<'_> {
         self.buf.as_audio_buffer_ref()
     }
 }

--- a/src/input/live_input.rs
+++ b/src/input/live_input.rs
@@ -136,7 +136,7 @@ impl LiveInput {
     /// Tries to get any information about this audio stream acquired during parsing.
     ///
     /// Only exists when this input is [`LiveInput::Parsed`].
-    pub fn metadata(&mut self) -> Result<Metadata, MetadataError> {
+    pub fn metadata(&mut self) -> Result<Metadata<'_>, MetadataError> {
         if let Some(parsed) = self.parsed_mut() {
             Ok(parsed.into())
         } else {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -215,7 +215,7 @@ impl Input {
     ///
     /// Only exists when this input is both [`Self::Live`] and has been fully parsed.
     /// In general, you probably want to use [`Self::aux_metadata`].
-    pub fn metadata(&mut self) -> Result<Metadata, MetadataError> {
+    pub fn metadata(&mut self) -> Result<Metadata<'_>, MetadataError> {
         if let Self::Live(live, _) = self {
             live.metadata()
         } else {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -205,8 +205,7 @@ impl Input {
     /// will always fail with [`AudioStreamError::Unsupported`].
     pub async fn aux_metadata(&mut self) -> Result<AuxMetadata, AuxMetadataError> {
         match self {
-            Self::Lazy(ref mut composer) => composer.aux_metadata().await.map_err(Into::into),
-            Self::Live(_, Some(ref mut composer)) =>
+            Self::Lazy(ref mut composer) | Self::Live(_, Some(ref mut composer)) =>
                 composer.aux_metadata().await.map_err(Into::into),
             Self::Live(_, None) => Err(AuxMetadataError::NoCompose),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
     // TODO: would require significant rewriting of all existing docs
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
+    clippy::doc_link_with_quotes,
 )]
 
 mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! [codecs and formats provided by Symphonia]: https://github.com/pdeljanov/Symphonia#formats-demuxers
 //! [audiopus]: https://github.com/lakelezz/audiopus
 
-#![warn(clippy::pedantic)]
+#![warn(clippy::pedantic, rust_2018_idioms)]
 #![allow(
     // Allowed as they are too pedantic
     clippy::module_name_repetitions,

--- a/src/tracks/command.rs
+++ b/src/tracks/command.rs
@@ -28,7 +28,7 @@ pub enum TrackCommand {
     /// Register an event on this track.
     AddEvent(EventData),
     /// Run some closure on this track, with direct access to the core object.
-    Do(Box<dyn FnOnce(View) -> Option<Action> + Send + Sync + 'static>),
+    Do(Box<dyn FnOnce(View<'_>) -> Option<Action> + Send + Sync + 'static>),
     /// Request a copy of this track's state.
     Request(Sender<TrackState>),
     /// Change the loop count/strategy of this track.

--- a/src/tracks/handle.rs
+++ b/src/tracks/handle.rs
@@ -150,7 +150,7 @@ impl TrackHandle {
     /// [`Metadata`]: crate::input::Metadata
     pub fn action<F>(&self, action: F) -> TrackResult<()>
     where
-        F: FnOnce(View) -> Option<Action> + Send + Sync + 'static,
+        F: FnOnce(View<'_>) -> Option<Action> + Send + Sync + 'static,
     {
         self.send(TrackCommand::Do(Box::new(action)))
     }

--- a/src/tracks/queue.rs
+++ b/src/tracks/queue.rs
@@ -193,8 +193,8 @@ impl TrackQueue {
 
     pub(crate) async fn get_preload_time(track: &mut Track) -> Option<Duration> {
         let meta = match track.input {
-            Input::Lazy(ref mut rec) => rec.aux_metadata().await.ok(),
-            Input::Live(_, Some(ref mut rec)) => rec.aux_metadata().await.ok(),
+            Input::Lazy(ref mut rec) | Input::Live(_, Some(ref mut rec)) =>
+                rec.aux_metadata().await.ok(),
             Input::Live(_, None) => None,
         };
 


### PR DESCRIPTION
This also adds the rust_2018_idioms warning group, to fix elided lifetimes.