### PR TITLE
 Allow borrowed strings for YoutubeDl 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ crypto_secretbox = { optional = true, features = ["std"], version = "0.1" }
 dashmap = { optional = true, version = "5" }
 derivative = "2"
 discortp = { default-features = false, features = ["discord", "pnet", "rtp"], optional = true, version = "0.6" }
+either = "1.9.0"
 flume = { optional = true, version = "0.11" }
 futures = "0.3"
 nohash-hasher = { optional = true, version = "0.2.0" }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -114,7 +114,7 @@ use tokio::runtime::Handle as TokioHandle;
 /// let mut lazy = YoutubeDl::new(
 ///     reqwest::Client::new(),
 ///     // Referenced under CC BY-NC-SA 3.0 -- https://creativecommons.org/licenses/by-nc-sa/3.0/
-///     "https://cloudkicker.bandcamp.com/track/94-days".to_string(),
+///     "https://cloudkicker.bandcamp.com/track/94-days",
 /// );
 /// let lazy_c = lazy.clone();
 ///

--- a/src/tracks/state.rs
+++ b/src/tracks/state.rs
@@ -55,7 +55,7 @@ mod tests {
         let (t_handle, config) = Config::test_cfg(true);
         let mut driver = Driver::new(config.clone());
 
-        let file = YoutubeDl::new(Client::new(), YTDL_TARGET.into());
+        let file = YoutubeDl::new(Client::new(), YTDL_TARGET);
         let handle = driver.play(Track::from(file));
 
         let state = t_handle


### PR DESCRIPTION
This changes `YoutubeDl` to have a lifetime, to allow users to provide `&str` references for the url/query. This can't currently be used for `Input`, where users have to provide `String` or `&'static str`, but is useful for users fetching metadata/searching.

This also makes `search` return `impl Iterator` to avoid the unnecessary `Vec` buffering possibly performed, which relies on `Either` as a primitive form of `enum_dispatch`, but it's already in the dep tree so it doesn't matter. 