### PR TITLE
Remove typemap from songbird

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 twilight-gateway = { default-features = false, optional = true, version = "0.15.0" }
 twilight-model = { default-features = false, optional = true, version = "0.15.0" }
-typemap_rev = { optional = true, version = "0.3" }
 url = { optional = true, version = "2" }
 uuid = { features = ["v4"], optional = true, version = "1" }
 
@@ -101,7 +100,6 @@ driver = [
     "dep:tokio",
     "dep:tokio-tungstenite",
     "dep:tokio-util",
-    "dep:typemap_rev",
     "dep:url",
     "dep:uuid",
     "tokio?/fs",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,6 @@ mod ws;
 pub use discortp as packet;
 #[cfg(feature = "driver")]
 pub use serenity_voice_model as model;
-#[cfg(feature = "driver")]
-pub use typemap_rev as typemap;
 
 // Re-export serde-json APIs locally to minimise conditional config elsewhere.
 #[cfg(not(feature = "simd-json"))]


### PR DESCRIPTION
Split off from #218, removes typemap from songbird by using a dyn Any instead. This is already the approach taken for user data in serenity:next.