### PR TITLE
Driver: Support `tokio-websockets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,13 @@ jobs:
             os: windows-latest
             dont-test: true
           - name: driver only
-            features: driver rustls
+            features: driver tungstenite rustls
             dont-test: true
           - name: gateway only
-            features: gateway serenity rustls
+            features: gateway serenity tungstenite rustls
             dont-test: true
           - name: simd json
-            features: simd-json serenity rustls driver gateway serenity?/simd_json
+            features: simd-json serenity tungstenite rustls driver gateway serenity?/simd_json
             rustflags: -C target-cpu=native
             dont-test: true
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ symphonia = { default_features = false, optional = true, version = "0.5.2" }
 symphonia-core = { optional = true, version = "0.5.2" }
 tokio = { default-features = false, optional = true, version = "1.0" }
 tokio-tungstenite = { optional = true, version = "0.21" }
+tokio-websockets = { optional = true, version = "0.5", features = ["client", "getrandom", "sha1_smol"] }
 tokio-util = { features = ["io"], optional = true, version = "0.7" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
@@ -68,6 +69,7 @@ default = [
     "gateway",
     "rustls",
     "serenity",
+    "tungstenite"
 ]
 gateway = [
     "dep:async-trait",
@@ -101,7 +103,6 @@ driver = [
     "dep:symphonia",
     "dep:symphonia-core",
     "dep:tokio",
-    "dep:tokio-tungstenite",
     "dep:tokio-util",
     "dep:typemap_rev",
     "dep:url",
@@ -119,14 +120,19 @@ rustls = [
     "reqwest?/rustls-tls",
     "serenity?/rustls_backend",
     "tokio-tungstenite?/rustls-tls-webpki-roots",
+    "tokio-websockets?/ring",
+    "tokio-websockets?/rustls-native-roots",
     "twilight-gateway?/rustls-native-roots",
 ]
 native = [
     "reqwest?/native-tls",
     "serenity?/native_tls_backend",
     "tokio-tungstenite?/native-tls",
+    "tokio-websockets?/native-tls",
     "twilight-gateway?/native",
 ]
+tungstenite = ["dep:tokio-tungstenite"]
+tws = ["dep:tokio-websockets"]
 twilight = ["dep:twilight-gateway","dep:twilight-model"]
 
 # Behaviour altering features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ builtin-queue = []
 receive = ["dep:bytes", "discortp?/demux", "discortp?/rtcp"]
 
 # Used for docgen/testing/benchmarking.
-full-doc = ["default", "twilight", "builtin-queue", "receive"]
+full-doc = ["default", "tungstenite", "twilight", "builtin-queue", "receive"]
 internals = ["dep:byteorder"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ symphonia = { default_features = false, optional = true, version = "0.5.2" }
 symphonia-core = { optional = true, version = "0.5.2" }
 tokio = { default-features = false, optional = true, version = "1.0" }
 tokio-tungstenite = { optional = true, version = "0.21" }
-tokio-websockets = { optional = true, version = "0.5", features = ["client", "getrandom", "sha1_smol"] }
+tokio-websockets = { optional = true, version = "0.5", features = ["client", "fastrand", "sha1_smol", "simd"] }
 tokio-util = { features = ["io"], optional = true, version = "0.7" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 reqwest = { workspace = true }
-songbird = { workspace = true, features = ["driver", "gateway", "twilight", "rustls"] }
+songbird = { workspace = true, features = ["driver", "gateway", "twilight", "rustls", "tws"] }
 symphonia = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 reqwest = { workspace = true }
-songbird = { workspace = true, features = ["driver", "gateway", "twilight", "rustls", "tws"] }
+songbird = { workspace = true, features = ["driver", "gateway", "twilight", "rustls", "tungstenite"] }
 symphonia = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -27,6 +27,12 @@ use tokio_websockets::{
 use tracing::{debug, instrument};
 use url::Url;
 
+#[cfg(any(
+    all(feature = "tws", feature = "tungstenite"),
+    all(not(feature = "tws"), not(feature = "tungstenite"))
+))]
+compile_error!("specify one of `features = [\"tungstenite\"]` (recommended w/ serenity) or `features = [\"tws\"]` (recommended w/ twilight)");
+
 pub struct WsStream(WebSocketStream<MaybeTlsStream<TcpStream>>);
 
 impl WsStream {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -5,6 +5,7 @@ use tokio::{
     net::TcpStream,
     time::{timeout, Duration},
 };
+#[cfg(feature = "tungstenite")]
 use tokio_tungstenite::{
     tungstenite::{
         error::Error as TungsteniteError,
@@ -12,6 +13,15 @@ use tokio_tungstenite::{
         Message,
     },
     MaybeTlsStream,
+    WebSocketStream,
+};
+#[cfg(feature = "tws")]
+use tokio_websockets::{
+    CloseCode,
+    Error as TwsError,
+    Limits,
+    MaybeTlsStream,
+    Message,
     WebSocketStream,
 };
 use tracing::{debug, instrument};
@@ -22,6 +32,7 @@ pub struct WsStream(WebSocketStream<MaybeTlsStream<TcpStream>>);
 impl WsStream {
     #[instrument]
     pub(crate) async fn connect(url: Url) -> Result<Self> {
+        #[cfg(feature = "tungstenite")]
         let (stream, _) = tokio_tungstenite::connect_async_with_config::<Url>(
             url,
             Some(Config {
@@ -32,6 +43,13 @@ impl WsStream {
             true,
         )
         .await?;
+        #[cfg(feature = "tws")]
+        let (stream, _) = tokio_websockets::ClientBuilder::new()
+            .limits(Limits::unlimited())
+            .uri(url.as_str())
+            .unwrap() // Any valid URL is a valid URI.
+            .connect()
+            .await?;
 
         Ok(Self(stream))
     }
@@ -53,11 +71,12 @@ impl WsStream {
     }
 
     pub(crate) async fn send_json(&mut self, value: &Event) -> Result<()> {
-        Ok(crate::json::to_string(value)
-            .map(Message::Text)
-            .map_err(Error::from)
-            .map(|m| self.0.send(m))?
-            .await?)
+        let res = crate::json::to_string(value);
+        #[cfg(feature = "tungstenite")]
+        let res = res.map(Message::Text);
+        #[cfg(feature = "twilight")]
+        let res = res.map(Message::text);
+        Ok(res.map_err(Error::from).map(|m| self.0.send(m))?.await?)
     }
 }
 
@@ -71,9 +90,15 @@ pub enum Error {
     /// As a result, only text messages are expected.
     UnexpectedBinaryMessage(Vec<u8>),
 
+    #[cfg(feature = "tungstenite")]
     Ws(TungsteniteError),
+    #[cfg(feature = "tws")]
+    Ws(TwsError),
 
+    #[cfg(feature = "tungstenite")]
     WsClosed(Option<CloseFrame<'static>>),
+    #[cfg(feature = "tws")]
+    WsClosed(Option<CloseCode>),
 }
 
 impl From<JsonError> for Error {
@@ -82,8 +107,16 @@ impl From<JsonError> for Error {
     }
 }
 
+#[cfg(feature = "tungstenite")]
 impl From<TungsteniteError> for Error {
     fn from(e: TungsteniteError) -> Error {
+        Error::Ws(e)
+    }
+}
+
+#[cfg(feature = "tws")]
+impl From<TwsError> for Error {
+    fn from(e: TwsError) -> Self {
         Error::Ws(e)
     }
 }
@@ -91,7 +124,8 @@ impl From<TungsteniteError> for Error {
 #[inline]
 #[allow(unused_unsafe)]
 pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Event>> {
-    Ok(match message {
+    #[cfg(feature = "tungstenite")]
+    return Ok(match message {
         // SAFETY:
         // simd-json::serde::from_str may leave an &mut str in a non-UTF state on failure.
         // The below is safe as we have taken ownership of the inner `String`, and if
@@ -112,5 +146,33 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
         },
         // Ping/Pong message behaviour is internally handled by tungstenite.
         _ => None,
-    })
+    });
+    #[cfg(feature = "tws")]
+    return Ok(if let Some(message) = message {
+        if message.is_text() {
+            let mut payload = message.as_text().unwrap().to_owned();
+            // SAFETY:
+            // simd-json::serde::from_str may leave an &mut str in a non-UTF state on failure.
+            // The below is safe as we have created an owned copy of the payload `&str`, and if
+            // failure occurs we forcibly re-validate its contents before logging.
+            (unsafe { crate::json::from_str(payload.as_mut_str()) })
+                .map_err(|e| {
+                    let safe_payload = String::from_utf8_lossy(payload.as_bytes());
+                    debug!("Unexpected JSON: {e}. Payload: {safe_payload}");
+                    e
+                })
+                .ok()
+        } else if message.is_binary() {
+            return Err(Error::UnexpectedBinaryMessage(
+                message.into_payload().to_vec(),
+            ));
+        } else if message.is_close() {
+            return Err(Error::WsClosed(message.as_close().map(|(c, _)| c)));
+        } else {
+            // ping/pong; will also be internally handled by tokio-websockets
+            None
+        }
+    } else {
+        None
+    });
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -74,7 +74,7 @@ impl WsStream {
         let res = crate::json::to_string(value);
         #[cfg(feature = "tungstenite")]
         let res = res.map(Message::Text);
-        #[cfg(feature = "twilight")]
+        #[cfg(feature = "tws")]
         let res = res.map(Message::text);
         Ok(res.map_err(Error::from).map(|m| self.0.send(m))?.await?)
     }


### PR DESCRIPTION
Allows for configuring the crate to use [`tokio-websockets`](https://crates.io/crates/tokio-websockets) instead of `tokio-tungstenite` since Twilight 0.16 [is switching to TWS](https://github.com/twilight-rs/twilight/blob/main/book/src/versions/0.16/summary.md#switch-to-tokio-websockets-and-fastrand).