### PR TITLE
Driver: Fix slot length check on packet passthrough

### DIFF
--- a/src/driver/tasks/mixer/mix_logic.rs
+++ b/src/driver/tasks/mixer/mix_logic.rs
@@ -77,7 +77,7 @@ pub fn mix_symph_indiv(
                     // seen. The main one is that most Opus tracks end on a sub-20ms
                     // frame, particularly on Youtube.
                     // However, a frame that's bigger than the target buffer is an instant block.
-                    let buf_size_fatal = buf.len() <= slot.len();
+                    let buf_size_fatal = buf.len() >= slot.len();
 
                     if match sample_ct {
                         Ok(MONO_FRAME_SIZE) => true,


### PR DESCRIPTION
Corrects a buffer length check identified in #230 which was reversed, such that overly large Opus packets would panic on a subsequent `write_all`.