### PR TITLE
Driver: Fix multiple disconnect events on `leave`

### DIFF
--- a/src/events/context/data/disconnect.rs
+++ b/src/events/context/data/disconnect.rs
@@ -75,6 +75,10 @@ pub enum DisconnectReason {
     ProtocolViolation,
     /// A voice connection was not established in the specified time.
     TimedOut,
+    /// The call was manually disconnected by a user command, e.g. [`Driver::leave`].
+    ///
+    /// [`Driver::leave`]: crate::driver::Driver::leave
+    Requested,
     /// The Websocket connection was closed by Discord.
     ///
     /// This typically indicates that the voice session has expired,


### PR DESCRIPTION
Fixes behaviour where a `Driver` which was asked to leave an active call would receive the disconnect event several times: once when we started the disconnect, and once again when Discord killed the WS client.