### PR TITLE
Make DisposalThread reachable

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -64,6 +64,8 @@ use core::{
 use flume::{r#async::RecvFut, SendError, Sender};
 #[cfg(feature = "builtin-queue")]
 use std::time::Duration;
+#[allow(unused_imports)]
+pub use tasks::disposal::DisposalThread;
 use tasks::message::CoreMessage;
 use tracing::instrument;
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -18,7 +18,7 @@ mod decode_mode;
 mod mix_mode;
 pub mod retry;
 mod scheduler;
-pub(crate) mod tasks;
+pub mod tasks;
 #[cfg(test)]
 pub(crate) mod test_config;
 #[cfg(any(test, feature = "internals"))]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -18,7 +18,7 @@ mod decode_mode;
 mod mix_mode;
 pub mod retry;
 mod scheduler;
-pub mod tasks;
+pub(crate) mod tasks;
 #[cfg(test)]
 pub(crate) mod test_config;
 #[cfg(any(test, feature = "internals"))]

--- a/src/driver/tasks/disposal.rs
+++ b/src/driver/tasks/disposal.rs
@@ -12,6 +12,7 @@ impl Default for DisposalThread {
 }
 
 impl DisposalThread {
+    #[must_use]
     pub fn run() -> Self {
         let (mix_tx, mix_rx) = flume::unbounded();
         std::thread::spawn(move || {

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-pub(crate) mod disposal;
+pub mod disposal;
 pub mod error;
 mod events;
 pub mod message;

--- a/src/driver/tasks/mod.rs
+++ b/src/driver/tasks/mod.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-pub mod disposal;
+pub(crate) mod disposal;
 pub mod error;
 mod events;
 pub mod message;


### PR DESCRIPTION
The `Config` object provided to `Call`s and `Driver`s allows setting a `DisposalThread`, but since it is unreachable from outside the crate, the only way to properly set it is using a `Songbird` instance, which may not be adequate for all use cases. This PR just makes `DisposalThread` reachable from the outside.