### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -390,8 +390,8 @@ impl Config {
 
 // Test only attributes
 #[cfg(all(test, feature = "driver"))]
+#[allow(missing_docs)]
 impl Config {
-    #![allow(missing_docs)]
     #[must_use]
     pub fn tick_style(mut self, tick_style: TickStyle) -> Self {
         self.tick_style = tick_style;

--- a/src/driver/bench_internals.rs
+++ b/src/driver/bench_internals.rs
@@ -14,6 +14,7 @@ use crate::{
     tracks::{Track, TrackHandle},
 };
 
+#[must_use]
 pub fn track_context(t: Track) -> (TrackHandle, TrackContext) {
     t.into_context()
 }

--- a/src/driver/crypto.rs
+++ b/src/driver/crypto.rs
@@ -249,6 +249,7 @@ impl CryptoState {
     }
 
     /// Returns the underlying (stateless) type of the active crypto mode.
+    #[must_use]
     pub fn kind(self) -> CryptoMode {
         CryptoMode::from(self)
     }

--- a/src/driver/scheduler/config.rs
+++ b/src/driver/scheduler/config.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroUsize;
-
 use super::*;
 
 /// Configuration for how a [`Scheduler`] handles tasks.

--- a/src/driver/scheduler/idle.rs
+++ b/src/driver/scheduler/idle.rs
@@ -1,6 +1,5 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
 
-use flume::{Receiver, Sender};
 use nohash_hasher::{BuildNoHashHasher, IntMap};
 use tokio::time::{Instant as TokInstant, Interval};
 use tracing::info;

--- a/src/driver/scheduler/live.rs
+++ b/src/driver/scheduler/live.rs
@@ -1,10 +1,7 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use discortp::rtp::{MutableRtpPacket, RtpPacket};
-use flume::{Receiver, SendError, Sender, TryRecvError};
+use flume::{SendError, TryRecvError};
 use tokio::time::Instant as TokInstant;
 
 use crate::{
@@ -86,12 +83,14 @@ impl Worker {
     /// Return whether this thread has enough room (task count, spare cycles)
     /// for the given task.
     #[inline]
+    #[must_use]
     pub fn can_schedule(&self, task: &ParkedMixer, avoid: Option<WorkerId>) -> bool {
         avoid.map_or(true, |id| !self.has_id(id))
             && self.stats.has_room(&self.config.strategy, task)
     }
 
     #[inline]
+    #[must_use]
     pub fn stats(&self) -> Arc<LiveStatBlock> {
         self.stats.clone()
     }
@@ -108,6 +107,7 @@ impl Worker {
         self.tx.send((id, task))
     }
 
+    #[must_use]
     pub fn has_id(&self, id: WorkerId) -> bool {
         self.id == id
     }

--- a/src/driver/scheduler/task.rs
+++ b/src/driver/scheduler/task.rs
@@ -38,6 +38,7 @@ impl<T> IsEnabled for ResId<T> {}
 
 #[allow(missing_docs)]
 impl<T: Copy> ResId<T> {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -49,6 +50,7 @@ impl<T: Copy> ResId<T> {
     }
 
     #[cfg(any(test, feature = "internals"))]
+    #[must_use]
     pub fn get(self) -> u64 {
         self.0
     }
@@ -88,6 +90,7 @@ pub struct ParkedMixer {
 #[allow(missing_docs)]
 impl ParkedMixer {
     /// Create a new `Mixer` in a parked state.
+    #[must_use]
     pub fn new(mix_rx: Receiver<MixerMessage>, interconnect: Interconnect, config: Config) -> Self {
         Self {
             mixer: Box::new(Mixer::new(mix_rx, Handle::current(), interconnect, config)),

--- a/src/driver/tasks/error.rs
+++ b/src/driver/tasks/error.rs
@@ -25,8 +25,7 @@ pub enum Error {
     IllegalVoicePacket,
     InterconnectFailure(Recipient),
     Io(IoError),
-    Opus(OpusError),
-    Ws(WsError),
+    Other,
 }
 
 impl Error {
@@ -66,8 +65,8 @@ impl From<IoError> for Error {
 }
 
 impl From<OpusError> for Error {
-    fn from(e: OpusError) -> Error {
-        Error::Opus(e)
+    fn from(_: OpusError) -> Error {
+        Error::Other
     }
 }
 
@@ -97,7 +96,7 @@ impl From<SendError<UdpRxMessage>> for Error {
 }
 
 impl From<WsError> for Error {
-    fn from(e: WsError) -> Error {
-        Error::Ws(e)
+    fn from(_: WsError) -> Error {
+        Error::Other
     }
 }

--- a/src/driver/tasks/message/disposal.rs
+++ b/src/driver/tasks/message/disposal.rs
@@ -2,6 +2,7 @@
 
 use crate::{driver::tasks::mixer::InternalTrack, tracks::TrackHandle};
 
+#[allow(dead_code)] // We don't read because all we are doing is dropping.
 pub enum DisposalMessage {
     Track(Box<InternalTrack>),
     Handle(TrackHandle),

--- a/src/driver/tasks/message/mixer.rs
+++ b/src/driver/tasks/message/mixer.rs
@@ -40,6 +40,7 @@ pub enum MixerMessage {
 }
 
 impl MixerMessage {
+    #[must_use]
     pub fn is_mixer_maybe_live(&self) -> bool {
         matches!(
             self,

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -64,7 +64,6 @@ pub struct Mixer {
     pub bitrate: Bitrate,
     pub config: Arc<Config>,
     pub conn_active: Option<MixerConnection>,
-    pub content_prep_sequence: u64,
     pub deadline: Instant,
     pub disposer: DisposalThread,
     pub encoder: OpusEncoder,
@@ -103,6 +102,7 @@ fn new_encoder(bitrate: Bitrate, mix_mode: MixMode) -> Result<OpusEncoder> {
 }
 
 impl Mixer {
+    #[must_use]
     pub fn new(
         mix_rx: Receiver<MixerMessage>,
         async_handle: Handle,
@@ -151,7 +151,6 @@ impl Mixer {
             bitrate,
             config,
             conn_active: None,
-            content_prep_sequence: 0,
             deadline,
             disposer,
             encoder,

--- a/src/driver/tasks/mixer/state.rs
+++ b/src/driver/tasks/mixer/state.rs
@@ -23,6 +23,7 @@ impl InputState {
         }
     }
 
+    #[must_use]
     pub fn ready_state(&self) -> ReadyState {
         match self {
             Self::NotReady(_) => ReadyState::Uninitialised,

--- a/src/driver/tasks/udp_rx/playout_buffer.rs
+++ b/src/driver/tasks/udp_rx/playout_buffer.rs
@@ -1,6 +1,5 @@
 use super::*;
 use bytes::Bytes;
-use discortp::rtp::RtpPacket;
 use std::collections::VecDeque;
 use tracing::trace;
 

--- a/src/driver/tasks/udp_rx/ssrc_state.rs
+++ b/src/driver/tasks/udp_rx/ssrc_state.rs
@@ -3,11 +3,9 @@ use crate::{
     constants::*,
     driver::{
         tasks::error::{Error, Result},
-        CryptoMode,
         DecodeMode,
     },
     events::context_data::{RtpData, VoiceData},
-    Config,
 };
 use audiopus::{
     coder::Decoder as OpusDecoder,
@@ -15,13 +13,7 @@ use audiopus::{
     packet::Packet as OpusPacket,
     Channels,
 };
-use discortp::{
-    rtp::{RtpExtensionPacket, RtpPacket},
-    Packet,
-    PacketSize,
-};
-use std::{convert::TryInto, time::Duration};
-use tokio::time::Instant;
+use discortp::{rtp::RtpExtensionPacket, Packet, PacketSize};
 use tracing::{error, warn};
 
 #[derive(Debug)]

--- a/src/driver/test_impls.rs
+++ b/src/driver/test_impls.rs
@@ -12,7 +12,7 @@ use crate::{
     tracks::LoopState,
 };
 use crypto_secretbox::{KeyInit, XSalsa20Poly1305 as Cipher};
-use flume::{Receiver, Sender};
+use flume::Receiver;
 use std::{io::Cursor, net::UdpSocket, sync::Arc};
 use tokio::runtime::Handle;
 
@@ -38,6 +38,7 @@ pub type Listeners = (Receiver<CoreMessage>, Receiver<EventMessage>);
 pub type DummyMixer = (Mixer, Listeners);
 
 impl Mixer {
+    #[must_use]
     pub fn mock(handle: Handle, softclip: bool) -> DummyMixer {
         let (mix_tx, mix_rx) = flume::unbounded();
         let (core_tx, core_rx) = flume::unbounded();
@@ -88,6 +89,7 @@ impl Mixer {
         return (out, (core_rx, event_rx));
     }
 
+    #[must_use]
     pub fn test_with_float(num_tracks: usize, handle: Handle, softclip: bool) -> DummyMixer {
         let mut out = Self::mock(handle, softclip);
 
@@ -106,6 +108,7 @@ impl Mixer {
         out
     }
 
+    #[must_use]
     pub fn test_with_float_unending(handle: Handle, softclip: bool) -> (DummyMixer, TrackHandle) {
         let mut out = Self::mock(handle, softclip);
 
@@ -125,6 +128,7 @@ impl Mixer {
         (out, handle)
     }
 
+    #[must_use]
     pub fn test_with_float_drop(num_tracks: usize, handle: Handle) -> DummyMixer {
         let mut out = Self::mock(handle, true);
 
@@ -142,6 +146,7 @@ impl Mixer {
         out
     }
 
+    #[must_use]
     pub fn test_with_opus(handle: &Handle) -> DummyMixer {
         // should add a single opus-based track.
         // make this fully loaded to prevent any perf cost there.

--- a/src/events/data.rs
+++ b/src/events/data.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::{cmp::Ordering, time::Duration};
+use std::cmp::Ordering;
 
 /// Internal representation of an event, as handled by the audio context.
 pub struct EventData {

--- a/src/events/store.rs
+++ b/src/events/store.rs
@@ -3,10 +3,7 @@ use crate::{
     constants::*,
     tracks::{ReadyState, TrackHandle, TrackState},
 };
-use std::{
-    collections::{BinaryHeap, HashMap},
-    time::Duration,
-};
+use std::collections::{BinaryHeap, HashMap};
 use tracing::info;
 
 #[derive(Debug, Default)]

--- a/src/input/adapters/cached/compressed.rs
+++ b/src/input/adapters/cached/compressed.rs
@@ -19,7 +19,6 @@ use audiopus::{
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::{
-    convert::TryInto,
     io::{
         Cursor,
         Error as IoError,

--- a/src/input/codecs/dca/mod.rs
+++ b/src/input/codecs/dca/mod.rs
@@ -12,7 +12,6 @@ use symphonia::core::{
     meta::{Metadata as SymphMetadata, MetadataBuilder, MetadataLog, StandardTagKey, Tag, Value},
     probe::{Descriptor, Instantiate, QueryDescriptor},
     sample::SampleFormat,
-    units::TimeStamp,
 };
 
 impl QueryDescriptor for DcaReader {

--- a/src/input/codecs/raw.rs
+++ b/src/input/codecs/raw.rs
@@ -7,7 +7,6 @@ use symphonia::core::{
     io::{MediaSource, MediaSourceStream, ReadBytes, SeekBuffered},
     meta::{Metadata as SymphMetadata, MetadataLog},
     probe::{Descriptor, Instantiate, QueryDescriptor},
-    units::TimeStamp,
 };
 
 impl QueryDescriptor for RawReader {

--- a/src/input/sources/http.rs
+++ b/src/input/sources/http.rs
@@ -232,8 +232,6 @@ impl From<HttpRequest> for Input {
 
 #[cfg(test)]
 mod tests {
-    use reqwest::Client;
-
     use super::*;
     use crate::{
         constants::test_data::{HTTP_OPUS_TARGET, HTTP_TARGET, HTTP_WEBM_TARGET},

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -225,8 +225,6 @@ impl Compose for YoutubeDl {
 
 #[cfg(test)]
 mod tests {
-    use reqwest::Client;
-
     use super::*;
     use crate::constants::test_data::*;
     use crate::input::input_tests::*;

--- a/src/join.rs
+++ b/src/join.rs
@@ -9,7 +9,6 @@ use crate::{
 use core::{
     convert,
     future::Future,
-    marker::Unpin,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
     clippy::doc_link_with_quotes,
+    clippy::doc_markdown,
 )]
 
 mod config;

--- a/src/tracks/command.rs
+++ b/src/tracks/command.rs
@@ -1,10 +1,7 @@
 use super::*;
 use crate::events::EventData;
 use flume::Sender;
-use std::{
-    fmt::{Debug, Formatter, Result as FmtResult},
-    time::Duration,
-};
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 
 /// A request from external code using a [`TrackHandle`] to modify
 /// or act upon an [`Track`] object.

--- a/src/tracks/handle.rs
+++ b/src/tracks/handle.rs
@@ -1,10 +1,9 @@
 use super::*;
 use crate::events::{Event, EventData, EventHandler};
 use flume::{Receiver, Sender};
-use std::{fmt, sync::Arc, time::Duration};
+use std::{fmt, sync::Arc};
 use tokio::sync::RwLock;
 use typemap_rev::TypeMap;
-use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 /// Handle for safe control of a [`Track`] from other threads, outside
@@ -264,13 +263,7 @@ impl<T> TrackCallback<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        constants::test_data::FILE_WAV_TARGET,
-        driver::Driver,
-        input::File,
-        tracks::Track,
-        Config,
-    };
+    use crate::{constants::test_data::FILE_WAV_TARGET, driver::Driver, input::File, Config};
 
     #[tokio::test]
     #[ntest::timeout(10_000)]

--- a/src/tracks/state.rs
+++ b/src/tracks/state.rs
@@ -40,13 +40,7 @@ impl TrackState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        constants::test_data::YTDL_TARGET,
-        driver::Driver,
-        input::YoutubeDl,
-        tracks::Track,
-        Config,
-    };
+    use crate::{constants::test_data::YTDL_TARGET, driver::Driver, input::YoutubeDl, Config};
     use reqwest::Client;
 
     #[tokio::test]

--- a/src/tracks/view.rs
+++ b/src/tracks/view.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::input::Metadata;
-use std::time::Duration;
 
 /// Live track and input state exposed during [`TrackHandle::action`].
 ///


### PR DESCRIPTION
Some changes here seem breaking, but I'm pretty sure they are crate internal and that's why the warnings fired. This most likely needs checking though.