### PR TITLE
Bump dependencies 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ nohash-hasher = { optional = true, version = "0.2.0" }
 parking_lot = { optional = true, version = "0.12" }
 pin-project = "1"
 rand = { optional = true, version = "0.8" }
-reqwest = { default-features = false, features = ["stream"], optional = true, version = "0.11" }
+reqwest = { default-features = false, features = ["stream"], optional = true, version = "0.12.2" }
 ringbuf = { optional = true, version = "0.3" }
-rubato = { optional = true, version = "0.14.1" }
+rubato = { optional = true, version = "0.15.0" }
 rusty_pool = { optional = true, version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde-aux = { optional = true, version = "4"}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,13 +9,13 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-reqwest = "0.11"
+reqwest = "0.12"
 serenity = { features = ["cache", "framework", "standard_framework", "voice", "http", "rustls_backend"], version = "0.12" }
 songbird = { path = "../", version = "0.4" }
 symphonia = { features = ["aac", "mp3", "isomp4", "alac"], version = "0.5.2" }
 tokio = { features = ["macros", "rt-multi-thread", "signal", "sync"], version = "1" }
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 tracing-futures = "0.2"
 
 [profile.release]


### PR DESCRIPTION
This is a breaking change as reqwest is publically exposed via HttpRequest::client and maybe other fields.