### PR TITLE
fix(conn): Some operating systems does not allow 0 recv buffer

### DIFF
--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -115,7 +115,8 @@ impl Connection {
         } else {
             let socket = Socket::from(udp.into_std()?);
 
-            #[cfg(not(target_os = "macos"))]
+            // Some operating systems does not allow setting the recv buffer to 0.
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             socket.set_recv_buffer_size(0)?;
 
             UdpSocket::from_std(socket.into())?


### PR DESCRIPTION
This will cause FreeBSD to fail setting up the socket. It may also be true of some other operating systems, but these are the ones I have been able to test.

It works on Windows and Linux.