### PR TITLE
fix(dependecies): don't use default features for stream_lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serenity-voice-model = { optional = true, version = "0.2" }
 simd-json = { features = ["serde_impl"], optional = true, version = "0.13" }
 socket2 = { optional = true, version = "0.5" }
 streamcatcher = { optional = true, version = "1" }
-stream_lib = { optional = true, version = "0.4.1" }
+stream_lib = { default-features = false, optional = true, version = "0.4.2" }
 symphonia = { default_features = false, optional = true, version = "0.5.2" }
 symphonia-core = { optional = true, version = "0.5.2" }
 tokio = { default-features = false, optional = true, version = "1.0" }
@@ -121,12 +121,14 @@ driver = [
 rustls = [
     "reqwest?/rustls-tls",
     "serenity?/rustls_backend",
+    "stream_lib?/rustls-tls",
     "tokio-tungstenite?/rustls-tls-webpki-roots",
     "twilight-gateway?/rustls-native-roots",
 ]
 native = [
     "reqwest?/native-tls",
     "serenity?/native_tls_backend",
+    "stream_lib?/native-tls",
     "tokio-tungstenite?/native-tls",
     "twilight-gateway?/native",
 ]


### PR DESCRIPTION
stream_lib would always pull in native-tls, this was changed in 0.4.2
which contains a backport of https://github.com/Erk-/rsget/pull/45.