### PR TITLE
fix(source): HLS would not work if used directly.

### DIFF
--- a/src/input/sources/hls.rs
+++ b/src/input/sources/hls.rs
@@ -16,6 +16,11 @@ use crate::input::{
 };
 
 /// Lazy HLS stream
+///
+/// # Note:
+///
+/// `Compose::create` for this struct panics if called outside of a
+/// tokio executor since it uses background tasks.
 #[derive(Debug)]
 pub struct HlsRequest {
     /// HTTP client
@@ -82,11 +87,11 @@ impl Compose for HlsRequest {
     async fn create_async(
         &mut self,
     ) -> Result<AudioStream<Box<dyn MediaSource>>, AudioStreamError> {
-        Err(AudioStreamError::Unsupported)
+        self.create()
     }
 
     fn should_create_async(&self) -> bool {
-        false
+        true
     }
 }
 


### PR DESCRIPTION
This changes HlsRequest to return true in
Compose::should_create_async.

This would otherwise cause it to be spawned on a thread without a
executor causing it to panic.

This would only cause issues if used directly since we otherwise use
Compose::create in a context where we have access to the executor.

Closes #257 

## Open questions:

- [x] Should the `create` implementation be removed or have a note that it will panic if called outside of a tokio executor?