### PR TITLE
Clear track_handles when SetTrack heard

### DIFF
--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -231,6 +231,7 @@ impl Mixer {
             MixerMessage::AddTrack(t) => self.add_track(t),
             MixerMessage::SetTrack(t) => {
                 self.tracks.clear();
+                self.track_handles.clear();
 
                 let mut out = self.fire_event(EventMessage::RemoveAllTracks);
 


### PR DESCRIPTION
## Summary

Clear `track_handles` when `SetTrack` heard, to prevent issue where indexes of `tracks` become desynced with indexes of `track_handles`. See #232 

## Testing

Not done, waiting for confirmation that this is a sensible fix