### PR TITLE
Playlist fixes, add `YoutubeDl::get_stream` function

### DIFF
--- a/src/input/metadata/mod.rs
+++ b/src/input/metadata/mod.rs
@@ -1,9 +1,11 @@
+//! Metadata about outputs - currently only [`ytdl::Output`] is publicly exported.
+
 use crate::error::JsonError;
 use std::time::Duration;
 use symphonia_core::{meta::Metadata as ContainerMetadata, probe::ProbedMetadata};
 
 pub(crate) mod ffprobe;
-pub(crate) mod ytdl;
+pub mod ytdl;
 
 use super::Parsed;
 

--- a/src/input/metadata/mod.rs
+++ b/src/input/metadata/mod.rs
@@ -1,11 +1,12 @@
-//! Metadata about outputs - currently only [`ytdl::Output`] is publicly exported.
+//! Metadata formats specific to [`Compose`] types.
 
 use crate::error::JsonError;
 use std::time::Duration;
 use symphonia_core::{meta::Metadata as ContainerMetadata, probe::ProbedMetadata};
 
 pub(crate) mod ffprobe;
-pub mod ytdl;
+mod ytdl;
+pub use ytdl::Output as YoutubeDlOutput;
 
 use super::Parsed;
 

--- a/src/input/metadata/mod.rs
+++ b/src/input/metadata/mod.rs
@@ -1,4 +1,4 @@
-//! Metadata formats specific to [`Compose`] types.
+//! Metadata formats specific to [`crate::input::Compose`] types.
 
 use crate::error::JsonError;
 use std::time::Duration;

--- a/src/input/metadata/ytdl.rs
+++ b/src/input/metadata/ytdl.rs
@@ -1,4 +1,4 @@
-//! YoutubeDl track metadata - see [`Output`].
+//! `YoutubeDl` track metadata.
 
 use super::AuxMetadata;
 use crate::constants::SAMPLE_RATE_RAW;
@@ -16,7 +16,7 @@ pub struct Output {
     pub album: Option<String>,
     /// The channel name.
     pub channel: Option<String>,
-    /// The duration of the stream.
+    /// The duration of the stream in seconds.
     pub duration: Option<f64>,
     /// The size of the stream.
     pub filesize: Option<u64>,
@@ -24,9 +24,9 @@ pub struct Output {
     pub http_headers: Option<HashMap<String, String>>,
     /// Release date of this track.
     pub release_date: Option<String>,
-    /// The track thumbnail.
+    /// The thumbnail URL for this track.
     pub thumbnail: Option<String>,
-    /// The title of the track.
+    /// The title of this track.
     pub title: Option<String>,
     /// The track name.
     pub track: Option<String>,

--- a/src/input/metadata/ytdl.rs
+++ b/src/input/metadata/ytdl.rs
@@ -1,28 +1,49 @@
+//! YoutubeDl track metadata - see [`Output`].
+
 use super::AuxMetadata;
 use crate::constants::SAMPLE_RATE_RAW;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 
+/// Information returned by yt-dlp about a URL. 
+/// 
+/// Returned by [`YoutubeDl::query`].
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Output {
+    /// The main artist.
     pub artist: Option<String>,
+    /// The album name.
     pub album: Option<String>,
+    /// The channel name.
     pub channel: Option<String>,
+    /// The duration of the stream.
     pub duration: Option<f64>,
+    /// The size of the stream.
     pub filesize: Option<u64>,
+    /// Required HTTP headers to fetch the track stream.
     pub http_headers: Option<HashMap<String, String>>,
+    /// Release date of this track.
     pub release_date: Option<String>,
+    /// The track thumbnail.
     pub thumbnail: Option<String>,
+    /// The title of the track.
     pub title: Option<String>,
+    /// The track name.
     pub track: Option<String>,
+    /// The date this track was uploaded on.
     pub upload_date: Option<String>,
+    /// The name of the uploader.
     pub uploader: Option<String>,
+    /// The stream URL.
     pub url: String,
+    /// The URL of the public-facing webpage for this track.
     pub webpage_url: Option<String>,
+    /// The stream protocol.
     pub protocol: Option<String>,
 }
 
 impl Output {
+    /// Requests auxiliary metadata which can be accessed without parsing the file.
     pub fn as_aux_metadata(&self) -> AuxMetadata {
         let album = self.album.clone();
         let track = self.track.clone();

--- a/src/input/metadata/ytdl.rs
+++ b/src/input/metadata/ytdl.rs
@@ -5,9 +5,9 @@ use crate::constants::SAMPLE_RATE_RAW;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 
-/// Information returned by yt-dlp about a URL. 
-/// 
-/// Returned by [`YoutubeDl::query`].
+/// Information returned by yt-dlp about a URL.
+///
+/// Returned by [`crate::input::YoutubeDl::query`].
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Output {
     /// The main artist.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -59,7 +59,7 @@ mod error;
 #[cfg(test)]
 pub mod input_tests;
 mod live_input;
-mod metadata;
+pub mod metadata;
 mod parsed;
 mod sources;
 pub mod utils;
@@ -70,7 +70,7 @@ pub use self::{
     compose::*,
     error::*,
     live_input::*,
-    metadata::{AuxMetadata, Metadata, YoutubeDlOutput},
+    metadata::{AuxMetadata, Metadata},
     parsed::*,
     sources::*,
 };

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -59,7 +59,7 @@ mod error;
 #[cfg(test)]
 pub mod input_tests;
 mod live_input;
-pub mod metadata;
+mod metadata;
 mod parsed;
 mod sources;
 pub mod utils;
@@ -70,7 +70,7 @@ pub use self::{
     compose::*,
     error::*,
     live_input::*,
-    metadata::*,
+    metadata::{AuxMetadata, Metadata, YoutubeDlOutput},
     parsed::*,
     sources::*,
 };

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -59,7 +59,7 @@ mod error;
 #[cfg(test)]
 pub mod input_tests;
 mod live_input;
-mod metadata;
+pub mod metadata;
 mod parsed;
 mod sources;
 pub mod utils;

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -117,7 +117,8 @@ impl<'a> YoutubeDl<'a> {
     ) -> Result<impl Iterator<Item = AuxMetadata>, AudioStreamError> {
         let n_results = n_results.unwrap_or(5);
 
-        Ok(self.query(n_results)
+        Ok(self
+            .query(n_results)
             .await?
             .into_iter()
             .map(|v| v.as_aux_metadata()))
@@ -180,7 +181,10 @@ impl<'a> YoutubeDl<'a> {
     }
 
     /// Get the audio stream from an [`Output`].
-    pub async fn get_stream(&self, result: &Output) -> Result<AudioStream<Box<dyn MediaSource>>, AudioStreamError> {
+    pub async fn get_stream(
+        &self,
+        result: &Output,
+    ) -> Result<AudioStream<Box<dyn MediaSource>>, AudioStreamError> {
         let mut headers = HeaderMap::default();
 
         if let Some(map) = &result.http_headers {
@@ -210,28 +214,6 @@ impl<'a> YoutubeDl<'a> {
             },
         }
     }
-    /// Returns all audio streams from a list of [`Output`]s.
-    pub async fn get_streams(&self, outputs: Vec<Output>) -> Result<Vec<AudioStream<Box<dyn MediaSource>>>, AudioStreamError> {
-        Ok(
-            futures::future::join_all(outputs
-                .iter()
-                .map(|o| self.get_stream(o))
-            )
-            .await
-            .into_iter()
-            .filter_map(|res| {
-                match res {
-                    Ok(stream) => Some(stream),
-                    Err(e) => {
-                        tracing::error!("Error when fetching a yt-dlp stream: {}", e);
-                        None
-                    }
-                }
-            })
-            .collect()
-        )
-    }
-
 }
 
 impl From<YoutubeDl<'static>> for Input {

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -1,5 +1,5 @@
 use crate::input::{
-    metadata::ytdl::Output,
+    metadata::YoutubeDlOutput,
     AudioStream,
     AudioStreamError,
     AuxMetadata,
@@ -125,8 +125,8 @@ impl<'a> YoutubeDl<'a> {
     }
 
     /// Runs a search for the given query, returning a list of up to `n_results`
-    /// possible matches which are [`Output`] objects containing a valid URL.
-    pub async fn query(&mut self, n_results: usize) -> Result<Vec<Output>, AudioStreamError> {
+    /// possible matches.
+    pub async fn query(&mut self, n_results: usize) -> Result<Vec<YoutubeDlOutput>, AudioStreamError> {
         let query_str = self.query.as_cow_str(n_results);
         let ytdl_args = [
             "-j",
@@ -165,7 +165,7 @@ impl<'a> YoutubeDl<'a> {
             .split(|&b| b == b'\n')
             .filter(|&x| (!x.is_empty()))
             .map(serde_json::from_slice)
-            .collect::<Result<Vec<Output>, _>>()
+            .collect::<Result<Vec<YoutubeDlOutput>, _>>()
             .map_err(|e| AudioStreamError::Fail(Box::new(e)))?;
 
         let meta = out
@@ -180,10 +180,10 @@ impl<'a> YoutubeDl<'a> {
         Ok(out)
     }
 
-    /// Get the audio stream from an [`Output`].
+    /// Get the audio stream from a [`YoutubeDlOutput`].
     pub async fn get_stream(
         &self,
-        result: &Output,
+        result: &YoutubeDlOutput,
     ) -> Result<AudioStream<Box<dyn MediaSource>>, AudioStreamError> {
         let mut headers = HeaderMap::default();
 

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -178,6 +178,60 @@ impl<'a> YoutubeDl<'a> {
 
         Ok(out)
     }
+
+    /// Get the audio stream from an [`Output`].
+    pub async fn get_stream(&self, result: &Output) -> Result<AudioStream<Box<dyn MediaSource>>, AudioStreamError> {
+        let mut headers = HeaderMap::default();
+
+        if let Some(map) = &result.http_headers {
+            headers.extend(map.iter().filter_map(|(k, v)| {
+                Some((
+                    HeaderName::from_bytes(k.as_bytes()).ok()?,
+                    HeaderValue::from_str(v).ok()?,
+                ))
+            }));
+        }
+
+        #[allow(clippy::single_match_else)]
+        match result.protocol.as_deref() {
+            Some("m3u8_native") => {
+                let mut req =
+                    HlsRequest::new_with_headers(self.client.clone(), result.url.clone(), headers);
+                req.create()
+            },
+            _ => {
+                let mut req = HttpRequest {
+                    client: self.client.clone(),
+                    request: result.url.clone(),
+                    headers,
+                    content_length: result.filesize,
+                };
+                req.create_async().await
+            },
+        }
+    }
+    /// Returns all audio streams from a list of [`Output`]s.
+    pub async fn get_streams(&self, outputs: Vec<Output>) -> Result<Vec<AudioStream<Box<dyn MediaSource>>>, AudioStreamError> {
+        Ok(
+            futures::future::join_all(outputs
+                .iter()
+                .map(|o| self.get_stream(o))
+            )
+            .await
+            .into_iter()
+            .filter_map(|res| {
+                match res {
+                    Ok(stream) => Some(stream),
+                    Err(e) => {
+                        tracing::error!("Error when fetching a yt-dlp stream: {}", e);
+                        None
+                    }
+                }
+            })
+            .collect()
+        )
+    }
+
 }
 
 impl From<YoutubeDl<'static>> for Input {
@@ -199,34 +253,7 @@ impl Compose for YoutubeDl<'_> {
         let mut results = self.query(1).await?;
         let result = results.swap_remove(0);
 
-        let mut headers = HeaderMap::default();
-
-        if let Some(map) = result.http_headers {
-            headers.extend(map.iter().filter_map(|(k, v)| {
-                Some((
-                    HeaderName::from_bytes(k.as_bytes()).ok()?,
-                    HeaderValue::from_str(v).ok()?,
-                ))
-            }));
-        }
-
-        #[allow(clippy::single_match_else)]
-        match result.protocol.as_deref() {
-            Some("m3u8_native") => {
-                let mut req =
-                    HlsRequest::new_with_headers(self.client.clone(), result.url, headers);
-                req.create()
-            },
-            _ => {
-                let mut req = HttpRequest {
-                    client: self.client.clone(),
-                    request: result.url,
-                    headers,
-                    content_length: result.filesize,
-                };
-                req.create_async().await
-            },
-        }
+        self.get_stream(&result).await
     }
 
     fn should_create_async(&self) -> bool {

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -123,7 +123,9 @@ impl<'a> YoutubeDl<'a> {
             .map(|v| v.as_aux_metadata()))
     }
 
-    async fn query(&mut self, n_results: usize) -> Result<Vec<Output>, AudioStreamError> {
+    /// Runs a search for the given query, returning a list of up to `n_results`
+    /// possible matches which are [`Output`] objects containing a valid URL.
+    pub async fn query(&mut self, n_results: usize) -> Result<Vec<Output>, AudioStreamError> {
         let query_str = self.query.as_cow_str(n_results);
         let ytdl_args = [
             "-j",

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -126,7 +126,10 @@ impl<'a> YoutubeDl<'a> {
 
     /// Runs a search for the given query, returning a list of up to `n_results`
     /// possible matches.
-    pub async fn query(&mut self, n_results: usize) -> Result<Vec<YoutubeDlOutput>, AudioStreamError> {
+    pub async fn query(
+        &mut self,
+        n_results: usize,
+    ) -> Result<Vec<YoutubeDlOutput>, AudioStreamError> {
         let query_str = self.query.as_cow_str(n_results);
         let ytdl_args = [
             "-j",

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -8,7 +8,6 @@ use crate::input::{
     Input,
 };
 use async_trait::async_trait;
-use either::Either;
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
     Client,
@@ -118,16 +117,10 @@ impl<'a> YoutubeDl<'a> {
     ) -> Result<impl Iterator<Item = AuxMetadata>, AudioStreamError> {
         let n_results = n_results.unwrap_or(5);
 
-        Ok(match &self.query {
-            // Safer to just return the metadata for the pointee if possible
-            QueryType::Url(_) => Either::Left(std::iter::once(self.aux_metadata().await?)),
-            QueryType::Search(_) => Either::Right(
-                self.query(n_results)
-                    .await?
-                    .into_iter()
-                    .map(|v| v.as_aux_metadata()),
-            ),
-        })
+        Ok(self.query(n_results)
+            .await?
+            .into_iter()
+            .map(|v| v.as_aux_metadata()))
     }
 
     async fn query(&mut self, n_results: usize) -> Result<Vec<Output>, AudioStreamError> {


### PR DESCRIPTION
Example usage of `YoutubeDl::get_stream`: https://codeberg.org/sapphiree/poise-music-bot/src/commit/3b06c53a32ac2657c36648205c00b75fc55a62ce/src/main.rs#L205
My main motivation for making these changes is that adding a full playlist was *really* slow before due to not having access to the stream URL, so I had to re-invoke yt-dlp for every entry. I don't believe this will break existing code.
The doc comments are mostly copied from other places and are probably insufficient, sorry about that.

Also closes #277.