### PR TITLE
Driver: Update the head and tail offsets returned from decrypt_*_in_place().

### DIFF
--- a/src/driver/crypto.rs
+++ b/src/driver/crypto.rs
@@ -412,8 +412,8 @@ impl Cipher {
         // Update the start estimate to account for bytes occupied by extension headers.
         let payload_offset = if has_extension {
             let payload = packet.payload();
-            let extension = RtpExtensionPacket::new(payload)
-                .ok_or(InternalError::IllegalVoicePacket)?;
+            let extension =
+                RtpExtensionPacket::new(payload).ok_or(InternalError::IllegalVoicePacket)?;
             extension.packet().len() - extension.payload().len()
         } else {
             0
@@ -484,7 +484,10 @@ impl Cipher {
             },
         }
 
-        Ok((plaintext_end + pre_payload.len(), post_payload.len() + slice_to_use.len()))
+        Ok((
+            plaintext_end + pre_payload.len(),
+            post_payload.len() + slice_to_use.len(),
+        ))
     }
 }
 

--- a/src/driver/crypto.rs
+++ b/src/driver/crypto.rs
@@ -407,19 +407,19 @@ impl Cipher {
             0
         };
 
-        let (mut start_estimate, end) = self.decrypt_pkt_in_place(packet, plain_bytes)?;
+        let (_, end) = self.decrypt_pkt_in_place(packet, plain_bytes)?;
 
         // Update the start estimate to account for bytes occupied by extension headers.
-        if has_extension {
-            let packet = packet.packet();
-            if let Some((_, exts_and_opus)) = split_at_checked(packet, start_estimate) {
-                let extension = RtpExtensionPacket::new(exts_and_opus)
-                    .ok_or(InternalError::IllegalVoicePacket)?;
-                start_estimate += extension.packet().len() - extension.payload().len();
-            }
-        }
+        let payload_offset = if has_extension {
+            let payload = packet.payload();
+            let extension = RtpExtensionPacket::new(payload)
+                .ok_or(InternalError::IllegalVoicePacket)?;
+            extension.packet().len() - extension.payload().len()
+        } else {
+            0
+        };
 
-        Ok((start_estimate, end))
+        Ok((payload_offset, end))
     }
 
     #[cfg(feature = "receive")]
@@ -484,23 +484,12 @@ impl Cipher {
             },
         }
 
-        Ok((plaintext_end + pre_payload.len(), post_payload.len()))
+        Ok((plaintext_end + pre_payload.len(), post_payload.len() + slice_to_use.len()))
     }
 }
 
 // Temporary functions -- MSRV is ostensibly 1.74, slice::split_at(_mut)_checked is 1.80+.
 // TODO: Remove in v0.5+ with MSRV bump to 1.81+.
-#[cfg(any(feature = "receive", test))]
-#[inline]
-#[must_use]
-const fn split_at_checked(els: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
-    if mid <= els.len() {
-        Some(els.split_at(mid))
-    } else {
-        None
-    }
-}
-
 #[cfg(any(feature = "receive", test))]
 #[inline]
 #[must_use]


### PR DESCRIPTION
`payload_offset` is derived from `start_estimate`, which was calculated first taking the start estimate from `decrypt_pkt_in_place()`.

This value was calculated by jumping to the end of the extension header (based on it's fixed minimum size), and then splitting at another offset, `mode.payload_prefix_len()`. However, this only accounts for encryption prefixes, which are zero. Meaning, when `decrypt_pkt_in_place()` returns `plaintext_end + pre_payload.len()` (where `pre_payload.len()` is 0), the returned start offset begins at the end of the extension header, but at the beginning of the extension itself, not the Opus data.

Now, this may be intended; the docs say that the value returns the point where headers end. However, without also including the length of the extension data itself, this offset into the buffer isn't very useful. It may be worth having additional design discussion about the implications of this, and the intended usage of `payload_offset`.

Regardless, because the `start_estimate` returned from `decrypt_pkt_in_place()` is after the headers, later in `decrypt_rtp_in_place()` where `start_estimate` is used to split the payload, the result buffer `exts_and_opus` does not include the extension headers. This means that pnet does not have the header information to reconstruct the actual `payload` length (vs. `ext_data`, since the length field telling where to split the two is missing). This means the value which is added to `start_estimate`, `extension.packet().len() - extension.payload().len()`, is the length of the entire `exts_and_opus` buffer, putting the actual returned `payload_offset` far too large.

My solution is to not perform a split based on the return value of `decrypt_pkt_in_place()` at all. (It felt wrong to change around the body of `decrypt_pkt_in_place()`, since the split point happening after the extension header but before extension data is technically correct for decrypting ciphertext.) Instead, after decryption, I build a `RtpExtensionPacket` from the entire `packet.payload()`, which starts at the beginning of the extension headers. This allows for correct calculation of `payload_offset` from `extension.packet().len() - extension.payload().len()`. This value is then used directly instead of being added to a base value, or returned as 0 in the case of no extensions.

---

`payload_end_pad` is returned from `decrypt_rtp_in_place()`, which is just passing through the value from `decrypt_pkt_in_place()`. This was `post_payload.len()`.

The problem is that `post_payload` is gotten from splitting `body_remaining` at `suffix_split_point`, which is `body_remaining.len() - mode.tag_suffix_len()`; but `body_remaining` is the leftovers after `mode.nonce_slice()` is performed.

Thus, the size of `body_remaining` is `sizeof(nonce)` short. This error propagates through to `post_payload`, making the `post_payload.len()` return value incorrect; it should have the size of the nonce value added back in.

My solution for this was simply to return `post_payload.len() + slice_to_use.len()`.

---

Additionally, since `split_at_checked()` was only used to derive `exts_and_opus`, which I no longer use, and because it was already marked temporary, I've removed it.

---

`cargo make ready` passes all tests.

Resolves #280.