### PR TITLE
Fix YoutubeDl by updating `yt-dlp` format syntax

### DIFF
--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -1,11 +1,5 @@
 use crate::input::{
-    metadata::ytdl::Output,
-    AudioStream,
-    AudioStreamError,
-    AuxMetadata,
-    Compose,
-    HttpRequest,
-    Input,
+    metadata::ytdl::Output, AudioStream, AudioStreamError, AuxMetadata, Compose, HttpRequest, Input,
 };
 use async_trait::async_trait;
 use either::Either;
@@ -136,7 +130,7 @@ impl<'a> YoutubeDl<'a> {
             "-j",
             &query_str,
             "-f",
-            "ba[abr>0][vcodec=none]/best",
+            "bestaudio[abr>0][vcodec=none]/bestaudio/best",
             "--no-playlist",
         ];
 

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -1,5 +1,11 @@
 use crate::input::{
-    metadata::ytdl::Output, AudioStream, AudioStreamError, AuxMetadata, Compose, HttpRequest, Input,
+    metadata::ytdl::Output,
+    AudioStream,
+    AudioStreamError,
+    AuxMetadata,
+    Compose,
+    HttpRequest,
+    Input,
 };
 use async_trait::async_trait;
 use either::Either;


### PR DESCRIPTION
This PR addresses [#245](https://github.com/serenity-rs/songbird/issues/245), which caused YouTube playback to fail due to recent changes in `yt-dlp` behavior.

Changed the `yt-dlp` format parameter (`-f`) to appropriate form to fix `Firing Error` occurred on `YoutubeDl` playback.