### PR TITLE
DAVE support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serenity = { default-features = false, optional = true, version = "0.12.0", feat
     "voice",
     "gateway",
 ] }
-serenity-voice-model = { optional = true, path = "../serenity/voice-model" }
+serenity-voice-model = { optional = true, git = "https://github.com/serenity-rs/serenity.git", branch = "next" }
 socket2 = { optional = true, version = "0.5" }
 streamcatcher = { optional = true, version = "1" }
 stream_lib = { default-features = false, optional = true, version = "0.5.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bytes = { optional = true, version = "1" }
 chacha20poly1305 = { optional = true, version = "0.10.1" }
 crypto-common = { optional = true, features = ["std"], version = "0.1" }
 dashmap = { optional = true, version = "6.1.0" }
-davey = { optional = true, version = "0.1.1" }
+davey = { optional = true, version = "0.1.2" }
 derivative = "2"
 discortp = { default-features = false, features = [
     "discord",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serenity = { default-features = false, optional = true, version = "0.12.0", feat
     "voice",
     "gateway",
 ] }
-serenity-voice-model = { optional = true, git = "https://github.com/serenity-rs/serenity.git", branch = "next" }
+serenity-voice-model = { optional = true, git = "https://github.com/serenity-rs/voice-model.git", branch = "next" }
 socket2 = { optional = true, version = "0.5" }
 streamcatcher = { optional = true, version = "1" }
 stream_lib = { default-features = false, optional = true, version = "0.5.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bytes = { optional = true, version = "1" }
 chacha20poly1305 = { optional = true, version = "0.10.1" }
 crypto-common = { optional = true, features = ["std"], version = "0.1" }
 dashmap = { optional = true, version = "6.1.0" }
+davey = { optional = true, version = "0.1.1" }
 derivative = "2"
 discortp = { default-features = false, features = [
     "discord",
@@ -49,7 +50,7 @@ serenity = { default-features = false, optional = true, version = "0.12.0", feat
     "voice",
     "gateway",
 ] }
-serenity-voice-model = { optional = true, version = "0.2" }
+serenity-voice-model = { optional = true, path = "../serenity/voice-model" }
 socket2 = { optional = true, version = "0.5" }
 streamcatcher = { optional = true, version = "1" }
 stream_lib = { default-features = false, optional = true, version = "0.5.2" }
@@ -100,6 +101,7 @@ driver = [
     "dep:bytes",
     "dep:chacha20poly1305",
     "dep:crypto-common",
+    "dep:davey",
     "dep:discortp",
     "dep:flume",
     "dep:nohash-hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serenity = { default-features = false, optional = true, version = "0.12.0", feat
     "voice",
     "gateway",
 ] }
-serenity-voice-model = { optional = true, git = "https://github.com/serenity-rs/voice-model.git", branch = "next" }
+serenity-voice-model = { optional = true, version = "0.3" }
 socket2 = { optional = true, version = "0.5" }
 streamcatcher = { optional = true, version = "1" }
 stream_lib = { default-features = false, optional = true, version = "0.5.2" }

--- a/examples/serenity/voice_receive/src/main.rs
+++ b/examples/serenity/voice_receive/src/main.rs
@@ -22,9 +22,7 @@ use serenity::{
     framework::{
         standard::{
             macros::{command, group},
-            Args,
-            CommandResult,
-            Configuration,
+            Args, CommandResult, Configuration,
         },
         StandardFramework,
     },
@@ -40,12 +38,7 @@ use songbird::{
         payload::{ClientDisconnect, Speaking},
     },
     packet::Packet,
-    Config,
-    CoreEvent,
-    Event,
-    EventContext,
-    EventHandler as VoiceEventHandler,
-    SerenityInit,
+    Config, CoreEvent, Event, EventContext, EventHandler as VoiceEventHandler, SerenityInit,
 };
 
 struct Handler;
@@ -166,14 +159,14 @@ impl VoiceEventHandler for Receiver {
             Ctx::RtpPacket(packet) => {
                 // An event which fires for every received audio packet,
                 // containing the decoded data.
-                let rtp = packet.rtp();
-                println!(
-                    "Received voice packet from SSRC {}, sequence {}, timestamp {} -- {}B long",
-                    rtp.get_ssrc(),
-                    rtp.get_sequence().0,
-                    rtp.get_timestamp().0,
-                    rtp.payload().len()
-                );
+                // let rtp = packet.rtp();
+                // println!(
+                //     "Received voice packet from SSRC {}, sequence {}, timestamp {} -- {}B long",
+                //     rtp.get_ssrc(),
+                //     rtp.get_sequence().0,
+                //     rtp.get_timestamp().0,
+                //     rtp.payload().len()
+                // );
             },
             Ctx::RtcpPacket(data) => {
                 // An event which fires for every received rtcp packet,

--- a/examples/serenity/voice_receive/src/main.rs
+++ b/examples/serenity/voice_receive/src/main.rs
@@ -38,7 +38,12 @@ use songbird::{
         payload::{ClientDisconnect, Speaking},
     },
     packet::Packet,
-    Config, CoreEvent, Event, EventContext, EventHandler as VoiceEventHandler, SerenityInit,
+    Config,
+    CoreEvent,
+    Event,
+    EventContext,
+    EventHandler as VoiceEventHandler,
+    SerenityInit,
 };
 
 struct Handler;
@@ -159,14 +164,14 @@ impl VoiceEventHandler for Receiver {
             Ctx::RtpPacket(packet) => {
                 // An event which fires for every received audio packet,
                 // containing the decoded data.
-                // let rtp = packet.rtp();
-                // println!(
-                //     "Received voice packet from SSRC {}, sequence {}, timestamp {} -- {}B long",
-                //     rtp.get_ssrc(),
-                //     rtp.get_sequence().0,
-                //     rtp.get_timestamp().0,
-                //     rtp.payload().len()
-                // );
+                let rtp = packet.rtp();
+                println!(
+                    "Received voice packet from SSRC {}, sequence {}, timestamp {} -- {}B long",
+                    rtp.get_ssrc(),
+                    rtp.get_sequence().0,
+                    rtp.get_timestamp().0,
+                    rtp.payload().len()
+                );
             },
             Ctx::RtcpPacket(data) => {
                 // An event which fires for every received rtcp packet,

--- a/examples/serenity/voice_receive/src/main.rs
+++ b/examples/serenity/voice_receive/src/main.rs
@@ -22,7 +22,9 @@ use serenity::{
     framework::{
         standard::{
             macros::{command, group},
-            Args, CommandResult, Configuration,
+            Args,
+            CommandResult,
+            Configuration,
         },
         StandardFramework,
     },

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -80,6 +80,11 @@ pub const RTP_VERSION: u8 = 2;
 /// Profile type used by Discord's Opus audio traffic.
 pub const RTP_PROFILE_TYPE: RtpType = RtpType::Dynamic(120);
 
+#[cfg(feature = "receive")]
+/// The magic marker appended to the end of DAVE encrypted payloads, used to determine
+/// whether the voice packet is encrypted.
+pub const DAVE_MAGIC_MARKER: [u8; 2] = [0xfa, 0xfa];
+
 #[cfg(test)]
 #[allow(clippy::doc_markdown, missing_docs)]
 pub mod test_data {

--- a/src/driver/connection/error.rs
+++ b/src/driver/connection/error.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 use aes_gcm::Error as CryptoError;
 use davey::errors::{
-    CreateKeyPackageError as DaveyCreateKeyPackageError, InitError as DaveyInitError,
+    CreateKeyPackageError as DaveyCreateKeyPackageError,
+    InitError as DaveyInitError,
 };
 use flume::SendError;
 use serde_json::Error as JsonError;

--- a/src/driver/connection/error.rs
+++ b/src/driver/connection/error.rs
@@ -25,6 +25,12 @@ pub enum Error {
     CryptoModeInvalid,
     /// Selected crypto mode was not offered by server.
     CryptoModeUnavailable,
+    /// Failed to create a DAVE key package.
+    #[cfg(feature = "driver")]
+    DaveCreateKeyPackageError(davey::errors::CreateKeyPackageError),
+    /// An error occured during initialization of the DAVE session.
+    #[cfg(feature = "driver")]
+    DaveInitializationError(davey::errors::InitError),
     /// An indicator that an endpoint URL was invalid.
     EndpointUrl,
     /// Discord failed to correctly respond to IP discovery.
@@ -100,6 +106,8 @@ impl fmt::Display for Error {
             Self::CryptoInvalidLength => write!(f, "server supplied key of wrong length"),
             Self::CryptoModeInvalid => write!(f, "server changed negotiated encryption mode"),
             Self::CryptoModeUnavailable => write!(f, "server did not offer chosen encryption mode"),
+            Self::DaveCreateKeyPackageError(e) => e.fmt(f),
+            Self::DaveInitializationError(e) => e.fmt(f),
             Self::EndpointUrl => write!(f, "endpoint URL received from gateway was invalid"),
             Self::IllegalDiscoveryResponse => {
                 write!(f, "IP discovery/NAT punching response was invalid")
@@ -122,6 +130,8 @@ impl StdError for Error {
             | Error::CryptoInvalidLength
             | Error::CryptoModeInvalid
             | Error::CryptoModeUnavailable
+            | Error::DaveCreateKeyPackageError(_)
+            | Error::DaveInitializationError(_)
             | Error::EndpointUrl
             | Error::IllegalDiscoveryResponse
             | Error::IllegalIp

--- a/src/driver/connection/error.rs
+++ b/src/driver/connection/error.rs
@@ -5,6 +5,9 @@ use crate::{
     ws::Error as WsError,
 };
 use aes_gcm::Error as CryptoError;
+use davey::errors::{
+    CreateKeyPackageError as DaveyCreateKeyPackageError, InitError as DaveyInitError,
+};
 use flume::SendError;
 use serde_json::Error as JsonError;
 use std::{error::Error as StdError, fmt, io::Error as IoError};
@@ -27,10 +30,10 @@ pub enum Error {
     CryptoModeUnavailable,
     /// Failed to create a DAVE key package.
     #[cfg(feature = "driver")]
-    DaveCreateKeyPackageError(davey::errors::CreateKeyPackageError),
+    DaveCreateKeyPackageError(DaveyCreateKeyPackageError),
     /// An error occured during initialization of the DAVE session.
     #[cfg(feature = "driver")]
-    DaveInitializationError(davey::errors::InitError),
+    DaveInitializationError(DaveyInitError),
     /// An indicator that an endpoint URL was invalid.
     EndpointUrl,
     /// Discord failed to correctly respond to IP discovery.

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -256,7 +256,6 @@ impl Connection {
 
         spawn(ws_task::runner(interconnect.clone(), ws_state));
 
-        // TODO: Implement DAVE for receive
         #[cfg(feature = "receive")]
         spawn(udp_rx::runner(
             interconnect.clone(),

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -8,15 +8,13 @@ use super::{
         message::*,
         ws::{self as ws_task, AuxNetwork},
     },
-    Config,
-    CryptoMode,
+    Config, CryptoMode,
 };
 use crate::{
     constants::*,
     model::{
         payload::{Identify, Resume, SelectProtocol},
-        Event as GatewayEvent,
-        ProtocolData,
+        Event as GatewayEvent, ProtocolData,
     },
     ws::WsStream,
     ConnectionInfo,
@@ -24,11 +22,11 @@ use crate::{
 use discortp::discord::{IpDiscoveryPacket, IpDiscoveryType, MutableIpDiscoveryPacket};
 use error::{Error, Result};
 use flume::Sender;
+use serenity_voice_model::payload::DaveMlsKeyPackage;
 use socket2::Socket;
-#[cfg(feature = "receive")]
 use std::sync::Arc;
-use std::{net::IpAddr, str::FromStr};
-use tokio::{net::UdpSocket, spawn, time::timeout};
+use std::{net::IpAddr, num::NonZeroU16, str::FromStr};
+use tokio::{net::UdpSocket, spawn, sync::RwLock, time::timeout};
 use tracing::{debug, info, instrument};
 use url::Url;
 
@@ -72,11 +70,12 @@ impl Connection {
                 session_id: info.session_id.clone(),
                 token: info.token.clone(),
                 user_id: info.user_id.into(),
+                max_dave_protocol_version: Some(davey::DAVE_PROTOCOL_VERSION),
             }))
             .await?;
 
         loop {
-            let Some(value) = client.recv_json().await? else {
+            let Some(value) = client.recv_event().await? else {
                 continue;
             };
 
@@ -181,7 +180,9 @@ impl Connection {
                 .await?;
         }
 
-        let cipher = init_cipher(&mut client, chosen_crypto, &ws_msg_tx).await?;
+        let (cipher, dave_session, dave_protocol_version) =
+            init_cipher(&mut client, &info, chosen_crypto, &ws_msg_tx).await?;
+        let dave_session = Arc::new(RwLock::new(dave_session));
 
         info!("Connected to: {}", info.endpoint);
 
@@ -213,6 +214,7 @@ impl Connection {
             cipher: cipher.clone(),
             #[cfg(not(feature = "receive"))]
             cipher,
+            dave_session: dave_session.clone(),
             crypto_state: chosen_crypto.into(),
             #[cfg(feature = "receive")]
             udp_rx: udp_receiver_msg_tx,
@@ -237,12 +239,15 @@ impl Connection {
             hello.heartbeat_interval,
             idx,
             info.clone(),
+            dave_session,
+            dave_protocol_version,
             #[cfg(feature = "receive")]
             ssrc_tracker.clone(),
         );
 
         spawn(ws_task::runner(interconnect.clone(), ws_state));
 
+        // TODO: Implement DAVE for receive
         #[cfg(feature = "receive")]
         spawn(udp_rx::runner(
             interconnect.clone(),
@@ -290,7 +295,7 @@ impl Connection {
         let mut resumed = None;
 
         loop {
-            let Some(value) = client.recv_json().await? else {
+            let Some(value) = client.recv_event().await? else {
                 continue;
             };
 
@@ -344,11 +349,12 @@ fn generate_url(endpoint: &mut String) -> Result<Url> {
 #[inline]
 async fn init_cipher(
     client: &mut WsStream,
+    info: &ConnectionInfo,
     mode: CryptoMode,
     tx: &Sender<WsMessage>,
-) -> Result<Cipher> {
+) -> Result<(Cipher, Option<davey::DaveSession>, Option<NonZeroU16>)> {
     loop {
-        let Some(value) = client.recv_json().await? else {
+        let Some(value) = client.recv_event().await? else {
             continue;
         };
 
@@ -358,9 +364,35 @@ async fn init_cipher(
                     return Err(Error::CryptoModeInvalid);
                 }
 
-                return mode
-                    .cipher_from_key(&desc.secret_key)
-                    .map_err(|_| Error::CryptoInvalidLength);
+                let dave_session =
+                    if let Some(version) = NonZeroU16::new(desc.dave_protocol_version) {
+                        let mut session = davey::DaveSession::new(
+                            version,
+                            info.user_id.0.into(),
+                            info.channel_id.expect("TODO").0.into(),
+                            None,
+                        )
+                        .map_err(|e| Error::DaveInitializationError(e))?;
+
+                        client
+                            .send_binary(&GatewayEvent::DaveMlsKeyPackage(DaveMlsKeyPackage {
+                                key_package: session
+                                    .create_key_package()
+                                    .map_err(|e| Error::DaveCreateKeyPackageError(e))?,
+                            }))
+                            .await?;
+
+                        Some(session)
+                    } else {
+                        None
+                    };
+
+                return Ok((
+                    mode.cipher_from_key(&desc.secret_key)
+                        .map_err(|_| Error::CryptoInvalidLength)?,
+                    dave_session,
+                    NonZeroU16::new(desc.dave_protocol_version),
+                ));
             },
             other => {
                 // Discord can and will send user-specific payload packets during this time

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -26,9 +26,9 @@ use error::{Error, Result};
 use flume::Sender;
 use serenity_voice_model::payload::DaveMlsKeyPackage;
 use socket2::Socket;
-use std::sync::{atomic::AtomicU16, Arc};
+use std::sync::{atomic::AtomicU16, Arc, RwLock};
 use std::{net::IpAddr, num::NonZeroU16, str::FromStr};
-use tokio::{net::UdpSocket, spawn, sync::RwLock, time::timeout};
+use tokio::{net::UdpSocket, spawn, time::timeout};
 use tracing::{debug, info, instrument};
 use url::Url;
 

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -22,11 +22,12 @@ use crate::{
 use discortp::discord::{IpDiscoveryPacket, IpDiscoveryType, MutableIpDiscoveryPacket};
 use error::{Error, Result};
 use flume::Sender;
+use parking_lot::RwLock as PRwLock;
 use serenity_voice_model::payload::DaveMlsKeyPackage;
 use socket2::Socket;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU16, Arc};
 use std::{net::IpAddr, num::NonZeroU16, str::FromStr};
-use tokio::{net::UdpSocket, spawn, sync::RwLock, time::timeout};
+use tokio::{net::UdpSocket, spawn, time::timeout};
 use tracing::{debug, info, instrument};
 use url::Url;
 
@@ -182,7 +183,8 @@ impl Connection {
 
         let (cipher, dave_session, dave_protocol_version) =
             init_cipher(&mut client, &info, chosen_crypto, &ws_msg_tx).await?;
-        let dave_session = Arc::new(RwLock::new(dave_session));
+        let dave_session = Arc::new(PRwLock::new(dave_session));
+        let dave_protocol_version = Arc::new(dave_protocol_version);
 
         info!("Connected to: {}", info.endpoint);
 
@@ -215,6 +217,7 @@ impl Connection {
             #[cfg(not(feature = "receive"))]
             cipher,
             dave_session: dave_session.clone(),
+            dave_protocol_version: dave_protocol_version.clone(),
             crypto_state: chosen_crypto.into(),
             #[cfg(feature = "receive")]
             udp_rx: udp_receiver_msg_tx,
@@ -239,8 +242,14 @@ impl Connection {
             hello.heartbeat_interval,
             idx,
             info.clone(),
+            #[cfg(not(feature = "receive"))]
             dave_session,
+            #[cfg(not(feature = "receive"))]
             dave_protocol_version,
+            #[cfg(feature = "receive")]
+            dave_session.clone(),
+            #[cfg(feature = "receive")]
+            dave_protocol_version.clone(),
             #[cfg(feature = "receive")]
             ssrc_tracker.clone(),
         );
@@ -257,6 +266,8 @@ impl Connection {
             config.clone(),
             udp_rx,
             ssrc_tracker,
+            dave_session,
+            dave_protocol_version,
         ));
 
         Ok(Connection {
@@ -352,7 +363,7 @@ async fn init_cipher(
     info: &ConnectionInfo,
     mode: CryptoMode,
     tx: &Sender<WsMessage>,
-) -> Result<(Cipher, Option<davey::DaveSession>, Option<NonZeroU16>)> {
+) -> Result<(Cipher, Option<davey::DaveSession>, AtomicU16)> {
     loop {
         let Some(value) = client.recv_event().await? else {
             continue;
@@ -369,7 +380,10 @@ async fn init_cipher(
                         let mut session = davey::DaveSession::new(
                             version,
                             info.user_id.0.into(),
-                            info.channel_id.expect("TODO").0.into(),
+                            info.channel_id
+                                .expect("channel ID must be set in connection info")
+                                .0
+                                .into(),
                             None,
                         )
                         .map_err(|e| Error::DaveInitializationError(e))?;
@@ -391,7 +405,7 @@ async fn init_cipher(
                     mode.cipher_from_key(&desc.secret_key)
                         .map_err(|_| Error::CryptoInvalidLength)?,
                     dave_session,
-                    NonZeroU16::new(desc.dave_protocol_version),
+                    AtomicU16::new(desc.dave_protocol_version),
                 ));
             },
             other => {

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -22,12 +22,11 @@ use crate::{
 use discortp::discord::{IpDiscoveryPacket, IpDiscoveryType, MutableIpDiscoveryPacket};
 use error::{Error, Result};
 use flume::Sender;
-use parking_lot::RwLock as PRwLock;
 use serenity_voice_model::payload::DaveMlsKeyPackage;
 use socket2::Socket;
 use std::sync::{atomic::AtomicU16, Arc};
 use std::{net::IpAddr, num::NonZeroU16, str::FromStr};
-use tokio::{net::UdpSocket, spawn, time::timeout};
+use tokio::{net::UdpSocket, spawn, sync::RwLock, time::timeout};
 use tracing::{debug, info, instrument};
 use url::Url;
 
@@ -183,7 +182,7 @@ impl Connection {
 
         let (cipher, dave_session, dave_protocol_version) =
             init_cipher(&mut client, &info, chosen_crypto, &ws_msg_tx).await?;
-        let dave_session = Arc::new(PRwLock::new(dave_session));
+        let dave_session = Arc::new(RwLock::new(dave_session));
         let dave_protocol_version = Arc::new(dave_protocol_version);
 
         info!("Connected to: {}", info.endpoint);

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -8,13 +8,15 @@ use super::{
         message::*,
         ws::{self as ws_task, AuxNetwork},
     },
-    Config, CryptoMode,
+    Config,
+    CryptoMode,
 };
 use crate::{
     constants::*,
     model::{
         payload::{Identify, Resume, SelectProtocol},
-        Event as GatewayEvent, ProtocolData,
+        Event as GatewayEvent,
+        ProtocolData,
     },
     ws::WsStream,
     ConnectionInfo,

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -386,13 +386,13 @@ async fn init_cipher(
                                 .into(),
                             None,
                         )
-                        .map_err(|e| Error::DaveInitializationError(e))?;
+                        .map_err(Error::DaveInitializationError)?;
 
                         client
                             .send_binary(&GatewayEvent::DaveMlsKeyPackage(DaveMlsKeyPackage {
                                 key_package: session
                                     .create_key_package()
-                                    .map_err(|e| Error::DaveCreateKeyPackageError(e))?,
+                                    .map_err(Error::DaveCreateKeyPackageError)?,
                             }))
                             .await?;
 

--- a/src/driver/tasks/error.rs
+++ b/src/driver/tasks/error.rs
@@ -2,6 +2,7 @@ use super::message::*;
 use crate::ws::Error as WsError;
 use aes_gcm::Error as CryptoError;
 use audiopus::Error as OpusError;
+use davey::errors::EncryptError as DaveyEncryptError;
 use flume::SendError;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
@@ -20,7 +21,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     Crypto(CryptoError),
-    DaveEncrypt(davey::errors::EncryptError),
+    DaveEncrypt,
     #[cfg(any(feature = "receive", test))]
     /// Received an illegal voice packet on the voice UDP socket.
     IllegalVoicePacket,
@@ -59,9 +60,9 @@ impl From<CryptoError> for Error {
     }
 }
 
-impl From<davey::errors::EncryptError> for Error {
-    fn from(value: davey::errors::EncryptError) -> Self {
-        Self::DaveEncrypt(value)
+impl From<DaveyEncryptError> for Error {
+    fn from(_e: DaveyEncryptError) -> Self {
+        Self::DaveEncrypt
     }
 }
 
@@ -111,39 +112,39 @@ impl From<WsError> for Error {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum DaveReinitError {
-    Init(davey::errors::InitError),
-    Reinit(davey::errors::ReinitError),
-    Reset(davey::errors::ResetError),
-    CreateKeyPackage(davey::errors::CreateKeyPackageError),
+    Init,
+    Reinit,
+    Reset,
+    CreateKeyPackage,
     Ws(WsError),
 }
 
 impl From<davey::errors::InitError> for DaveReinitError {
-    fn from(value: davey::errors::InitError) -> Self {
-        Self::Init(value)
+    fn from(_e: davey::errors::InitError) -> Self {
+        Self::Init
     }
 }
 
 impl From<davey::errors::ReinitError> for DaveReinitError {
-    fn from(value: davey::errors::ReinitError) -> Self {
-        Self::Reinit(value)
+    fn from(_e: davey::errors::ReinitError) -> Self {
+        Self::Reinit
     }
 }
 
 impl From<davey::errors::ResetError> for DaveReinitError {
-    fn from(value: davey::errors::ResetError) -> Self {
-        Self::Reset(value)
+    fn from(_e: davey::errors::ResetError) -> Self {
+        Self::Reset
     }
 }
 
 impl From<davey::errors::CreateKeyPackageError> for DaveReinitError {
-    fn from(value: davey::errors::CreateKeyPackageError) -> Self {
-        Self::CreateKeyPackage(value)
+    fn from(_e: davey::errors::CreateKeyPackageError) -> Self {
+        Self::CreateKeyPackage
     }
 }
 
 impl From<WsError> for DaveReinitError {
-    fn from(value: WsError) -> Self {
-        Self::Ws(value)
+    fn from(e: WsError) -> Self {
+        Self::Ws(e)
     }
 }

--- a/src/driver/tasks/error.rs
+++ b/src/driver/tasks/error.rs
@@ -20,6 +20,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     Crypto(CryptoError),
+    DaveEncrypt(davey::errors::EncryptError),
     #[cfg(any(feature = "receive", test))]
     /// Received an illegal voice packet on the voice UDP socket.
     IllegalVoicePacket,
@@ -55,6 +56,12 @@ impl Error {
 impl From<CryptoError> for Error {
     fn from(e: CryptoError) -> Self {
         Error::Crypto(e)
+    }
+}
+
+impl From<davey::errors::EncryptError> for Error {
+    fn from(value: davey::errors::EncryptError) -> Self {
+        Self::DaveEncrypt(value)
     }
 }
 
@@ -98,5 +105,45 @@ impl From<SendError<UdpRxMessage>> for Error {
 impl From<WsError> for Error {
     fn from(_: WsError) -> Error {
         Error::Other
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum DaveReinitError {
+    Init(davey::errors::InitError),
+    Reinit(davey::errors::ReinitError),
+    Reset(davey::errors::ResetError),
+    CreateKeyPackage(davey::errors::CreateKeyPackageError),
+    Ws(WsError),
+}
+
+impl From<davey::errors::InitError> for DaveReinitError {
+    fn from(value: davey::errors::InitError) -> Self {
+        Self::Init(value)
+    }
+}
+
+impl From<davey::errors::ReinitError> for DaveReinitError {
+    fn from(value: davey::errors::ReinitError) -> Self {
+        Self::Reinit(value)
+    }
+}
+
+impl From<davey::errors::ResetError> for DaveReinitError {
+    fn from(value: davey::errors::ResetError) -> Self {
+        Self::Reset(value)
+    }
+}
+
+impl From<davey::errors::CreateKeyPackageError> for DaveReinitError {
+    fn from(value: davey::errors::CreateKeyPackageError) -> Self {
+        Self::CreateKeyPackage(value)
+    }
+}
+
+impl From<WsError> for DaveReinitError {
+    fn from(value: WsError) -> Self {
+        Self::Ws(value)
     }
 }

--- a/src/driver/tasks/message/mixer.rs
+++ b/src/driver/tasks/message/mixer.rs
@@ -9,14 +9,18 @@ use crate::{
     input::{AudioStreamError, Compose, Parsed},
 };
 use flume::Sender;
-use std::{net::UdpSocket, sync::Arc};
+use parking_lot::RwLock as PRwLock;
+use std::{
+    net::UdpSocket,
+    sync::{atomic::AtomicU16, Arc},
+};
 use symphonia_core::{errors::Error as SymphoniaError, formats::SeekedTo};
-use tokio::sync::RwLock;
 
 pub struct MixerConnection {
     pub cipher: Cipher,
     pub crypto_state: CryptoState,
-    pub dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
+    pub dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    pub dave_protocol_version: Arc<AtomicU16>,
     #[cfg(feature = "receive")]
     pub udp_rx: Sender<UdpRxMessage>,
     pub udp_tx: UdpSocket,

--- a/src/driver/tasks/message/mixer.rs
+++ b/src/driver/tasks/message/mixer.rs
@@ -11,10 +11,12 @@ use crate::{
 use flume::Sender;
 use std::{net::UdpSocket, sync::Arc};
 use symphonia_core::{errors::Error as SymphoniaError, formats::SeekedTo};
+use tokio::sync::RwLock;
 
 pub struct MixerConnection {
     pub cipher: Cipher,
     pub crypto_state: CryptoState,
+    pub dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
     #[cfg(feature = "receive")]
     pub udp_rx: Sender<UdpRxMessage>,
     pub udp_tx: UdpSocket,

--- a/src/driver/tasks/message/mixer.rs
+++ b/src/driver/tasks/message/mixer.rs
@@ -11,10 +11,9 @@ use crate::{
 use flume::Sender;
 use std::{
     net::UdpSocket,
-    sync::{atomic::AtomicU16, Arc},
+    sync::{atomic::AtomicU16, Arc, RwLock},
 };
 use symphonia_core::{errors::Error as SymphoniaError, formats::SeekedTo};
-use tokio::sync::RwLock;
 
 pub struct MixerConnection {
     pub cipher: Cipher,

--- a/src/driver/tasks/message/mixer.rs
+++ b/src/driver/tasks/message/mixer.rs
@@ -9,17 +9,17 @@ use crate::{
     input::{AudioStreamError, Compose, Parsed},
 };
 use flume::Sender;
-use parking_lot::RwLock as PRwLock;
 use std::{
     net::UdpSocket,
     sync::{atomic::AtomicU16, Arc},
 };
 use symphonia_core::{errors::Error as SymphoniaError, formats::SeekedTo};
+use tokio::sync::RwLock;
 
 pub struct MixerConnection {
     pub cipher: Cipher,
     pub crypto_state: CryptoState,
-    pub dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    pub dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
     pub dave_protocol_version: Arc<AtomicU16>,
     #[cfg(feature = "receive")]
     pub udp_rx: Sender<UdpRxMessage>,

--- a/src/driver/tasks/message/udp_rx.rs
+++ b/src/driver/tasks/message/udp_rx.rs
@@ -14,4 +14,5 @@ pub enum UdpRxMessage {
 pub struct SsrcTracker {
     pub disconnected_users: DashSet<UserId>,
     pub user_ssrc_map: DashMap<UserId, u32>,
+    pub ssrc_user_map: DashMap<u32, UserId>,
 }

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -37,7 +37,7 @@ use rubato::{FftFixedOut, Resampler};
 use std::{
     io::Write,
     result::Result as StdResult,
-    sync::Arc,
+    sync::{atomic::Ordering, Arc},
     time::{Duration, Instant},
 };
 use symphonia_core::{
@@ -642,13 +642,26 @@ impl Mixer {
 
         // If passthrough, Opus payload in place already.
         // Else encode into buffer with space for AEAD encryption headers.
-        let payload_len = match mix_len {
+        let mut payload_len = match mix_len {
             MixType::Passthrough(opus_len) => opus_len,
             MixType::MixedPcm(_samples) => self.encoder.encode_float(
                 &send_buffer[..self.config.mix_mode.sample_count_in_frame()],
                 &mut payload[first_payload_byte..total_payload_space],
             )?,
         };
+
+        if conn.dave_protocol_version.load(Ordering::Relaxed) != 0 {
+            if let Some(ref mut dave_session) = *conn.dave_session.write() {
+                if dave_session.is_ready() {
+                    let encrypted = dave_session
+                        .encrypt_opus(&payload[first_payload_byte..payload_len])?
+                        .into_owned();
+                    payload_len = encrypted.len();
+
+                    payload[first_payload_byte..payload_len].copy_from_slice(&encrypted);
+                }
+            }
+        }
 
         let final_payload_size = conn
             .crypto_state

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -24,10 +24,7 @@ use crate::{
     Config,
 };
 use audiopus::{
-    coder::Encoder as OpusEncoder,
-    softclip::SoftClip,
-    Application as CodingMode,
-    Bitrate,
+    coder::Encoder as OpusEncoder, softclip::SoftClip, Application as CodingMode, Bitrate,
 };
 use discortp::{
     discord::MutableKeepalivePacket,
@@ -504,10 +501,12 @@ impl Mixer {
     #[inline]
     pub(crate) fn test_signal_empty_tick(&self) {
         match &self.config.override_connection {
-            Some(OutputMode::Raw(tx)) =>
-                drop(tx.send(crate::driver::test_config::TickMessage::NoEl)),
-            Some(OutputMode::Rtp(tx)) =>
-                drop(tx.send(crate::driver::test_config::TickMessage::NoEl)),
+            Some(OutputMode::Raw(tx)) => {
+                drop(tx.send(crate::driver::test_config::TickMessage::NoEl))
+            },
+            Some(OutputMode::Rtp(tx)) => {
+                drop(tx.send(crate::driver::test_config::TickMessage::NoEl))
+            },
             None => {},
         }
     }
@@ -639,18 +638,16 @@ impl Mixer {
         let payload = rtp.payload_mut();
         let crypto_mode = conn.crypto_state.kind();
         let first_payload_byte = crypto_mode.payload_prefix_len();
+        let total_payload_space = payload.len() - crypto_mode.payload_suffix_len();
 
         // If passthrough, Opus payload in place already.
         // Else encode into buffer with space for AEAD encryption headers.
         let payload_len = match mix_len {
             MixType::Passthrough(opus_len) => opus_len,
-            MixType::MixedPcm(_samples) => {
-                let total_payload_space = payload.len() - crypto_mode.payload_suffix_len();
-                self.encoder.encode_float(
-                    &send_buffer[..self.config.mix_mode.sample_count_in_frame()],
-                    &mut payload[first_payload_byte..total_payload_space],
-                )?
-            },
+            MixType::MixedPcm(_samples) => self.encoder.encode_float(
+                &send_buffer[..self.config.mix_mode.sample_count_in_frame()],
+                &mut payload[first_payload_byte..total_payload_space],
+            )?,
         };
 
         let final_payload_size = conn
@@ -849,8 +846,9 @@ impl Mixer {
             // to recreate? Probably not doable in the general case.
             match status {
                 MixStatus::Live => track.step_frame(),
-                MixStatus::Errored(e) =>
-                    track.playing = PlayMode::Errored(PlayError::Decode(e.into())),
+                MixStatus::Errored(e) => {
+                    track.playing = PlayMode::Errored(PlayError::Decode(e.into()))
+                },
                 MixStatus::Ended if track.do_loop() => {
                     drop(self.track_handles[i].seek(Duration::default()));
                     if !self.prevent_events {

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -40,7 +40,7 @@ use rubato::{FftFixedOut, Resampler};
 use std::{
     io::Write,
     result::Result as StdResult,
-    sync::{atomic::Ordering, Arc},
+    sync::Arc,
     time::{Duration, Instant},
 };
 use symphonia_core::{
@@ -58,6 +58,8 @@ use tracing::error;
 use crate::driver::test_config::{OutputMessage, OutputMode};
 #[cfg(test)]
 use discortp::Packet as _;
+#[cfg(not(test))]
+use std::sync::atomic::Ordering;
 
 pub struct Mixer {
     pub bitrate: Bitrate,
@@ -643,14 +645,20 @@ impl Mixer {
 
         // If passthrough, Opus payload in place already.
         // Else encode into buffer with space for AEAD encryption headers.
-        let mut payload_len = match mix_len {
+        let payload_len = match mix_len {
             MixType::Passthrough(opus_len) => opus_len,
             MixType::MixedPcm(_samples) => self.encoder.encode_float(
                 &send_buffer[..self.config.mix_mode.sample_count_in_frame()],
                 &mut payload[first_payload_byte..total_payload_space],
             )?,
         };
+        #[cfg(not(test))]
+        let mut payload_len = payload_len;
 
+        // DAVE encryption ignored in test mode. On test mode, this code is run
+        // on the Tokio main thread, causing RwLock::blocking_write to panic.
+        // In non-test scenarios this is run on a regular thread.
+        #[cfg(not(test))]
         if conn.dave_protocol_version.load(Ordering::Relaxed) != 0 {
             if let Some(ref mut dave_session) = *conn.dave_session.blocking_write() {
                 if dave_session.is_ready() {

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -651,7 +651,7 @@ impl Mixer {
         };
 
         if conn.dave_protocol_version.load(Ordering::Relaxed) != 0 {
-            if let Some(ref mut dave_session) = *conn.dave_session.write() {
+            if let Some(ref mut dave_session) = *conn.dave_session.blocking_write() {
                 if dave_session.is_ready() {
                     let encrypted = dave_session
                         .encrypt_opus(

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -654,11 +654,14 @@ impl Mixer {
             if let Some(ref mut dave_session) = *conn.dave_session.write() {
                 if dave_session.is_ready() {
                     let encrypted = dave_session
-                        .encrypt_opus(&payload[first_payload_byte..payload_len])?
+                        .encrypt_opus(
+                            &payload[first_payload_byte..first_payload_byte + payload_len],
+                        )?
                         .into_owned();
                     payload_len = encrypted.len();
 
-                    payload[first_payload_byte..payload_len].copy_from_slice(&encrypted);
+                    payload[first_payload_byte..first_payload_byte + payload_len]
+                        .copy_from_slice(&encrypted);
                 }
             }
         }

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -40,7 +40,7 @@ use rubato::{FftFixedOut, Resampler};
 use std::{
     io::Write,
     result::Result as StdResult,
-    sync::Arc,
+    sync::{atomic::Ordering, Arc},
     time::{Duration, Instant},
 };
 use symphonia_core::{
@@ -58,8 +58,6 @@ use tracing::error;
 use crate::driver::test_config::{OutputMessage, OutputMode};
 #[cfg(test)]
 use discortp::Packet as _;
-#[cfg(not(test))]
-use std::sync::atomic::Ordering;
 
 pub struct Mixer {
     pub bitrate: Bitrate,
@@ -645,22 +643,16 @@ impl Mixer {
 
         // If passthrough, Opus payload in place already.
         // Else encode into buffer with space for AEAD encryption headers.
-        let payload_len = match mix_len {
+        let mut payload_len = match mix_len {
             MixType::Passthrough(opus_len) => opus_len,
             MixType::MixedPcm(_samples) => self.encoder.encode_float(
                 &send_buffer[..self.config.mix_mode.sample_count_in_frame()],
                 &mut payload[first_payload_byte..total_payload_space],
             )?,
         };
-        #[cfg(not(test))]
-        let mut payload_len = payload_len;
 
-        // DAVE encryption ignored in test mode. On test mode, this code is run
-        // on the Tokio main thread, causing RwLock::blocking_write to panic.
-        // In non-test scenarios this is run on a regular thread.
-        #[cfg(not(test))]
         if conn.dave_protocol_version.load(Ordering::Relaxed) != 0 {
-            if let Some(ref mut dave_session) = *conn.dave_session.blocking_write() {
+            if let Some(ref mut dave_session) = *conn.dave_session.write().unwrap() {
                 if dave_session.is_ready() {
                     let encrypted = dave_session
                         .encrypt_opus(

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -24,7 +24,10 @@ use crate::{
     Config,
 };
 use audiopus::{
-    coder::Encoder as OpusEncoder, softclip::SoftClip, Application as CodingMode, Bitrate,
+    coder::Encoder as OpusEncoder,
+    softclip::SoftClip,
+    Application as CodingMode,
+    Bitrate,
 };
 use discortp::{
     discord::MutableKeepalivePacket,
@@ -501,12 +504,10 @@ impl Mixer {
     #[inline]
     pub(crate) fn test_signal_empty_tick(&self) {
         match &self.config.override_connection {
-            Some(OutputMode::Raw(tx)) => {
-                drop(tx.send(crate::driver::test_config::TickMessage::NoEl))
-            },
-            Some(OutputMode::Rtp(tx)) => {
-                drop(tx.send(crate::driver::test_config::TickMessage::NoEl))
-            },
+            Some(OutputMode::Raw(tx)) =>
+                drop(tx.send(crate::driver::test_config::TickMessage::NoEl)),
+            Some(OutputMode::Rtp(tx)) =>
+                drop(tx.send(crate::driver::test_config::TickMessage::NoEl)),
             None => {},
         }
     }
@@ -862,9 +863,8 @@ impl Mixer {
             // to recreate? Probably not doable in the general case.
             match status {
                 MixStatus::Live => track.step_frame(),
-                MixStatus::Errored(e) => {
-                    track.playing = PlayMode::Errored(PlayError::Decode(e.into()))
-                },
+                MixStatus::Errored(e) =>
+                    track.playing = PlayMode::Errored(PlayError::Decode(e.into())),
                 MixStatus::Ended if track.do_loop() => {
                     drop(self.track_handles[i].seek(Duration::default()));
                     if !self.prevent_events {

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -62,7 +62,7 @@ impl UdpRx {
                     let mut pkt = byte_dest.take().unwrap();
                     pkt.truncate(len);
 
-                    self.process_udp_message(interconnect, pkt);
+                    self.process_udp_message(interconnect, pkt).await;
                 },
                 msg = self.rx.recv_async() => {
                     match msg {
@@ -147,7 +147,7 @@ impl UdpRx {
         }
     }
 
-    fn process_udp_message(&mut self, interconnect: &Interconnect, mut packet: BytesMut) {
+    async fn process_udp_message(&mut self, interconnect: &Interconnect, mut packet: BytesMut) {
         // NOTE: errors here (and in general for UDP) are not fatal to the connection.
         // Panics should be avoided due to adversarial nature of rx'd packets,
         // but correct handling should not prompt a reconnect.
@@ -183,7 +183,7 @@ impl UdpRx {
                 // and we know who this voice packet came from
                 if let Some((rtp_body_start, rtp_body_tail, decrypted)) = packet_data {
                     if decrypted && self.dave_protocol_version.load(Ordering::Relaxed) != 0 {
-                        if let Some(ref mut dave_session) = *self.dave_session.blocking_write() {
+                        if let Some(ref mut dave_session) = *self.dave_session.write().await {
                             if dave_session.is_ready() {
                                 if let Some(user_id) =
                                     self.ssrc_signalling.ssrc_user_map.get(&rtp.get_ssrc())

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -223,8 +223,12 @@ impl UdpRx {
                                             body[..decrypted_payload.len()]
                                                 .copy_from_slice(&decrypted_payload);
                                         },
-                                        Err(e) => {
-                                            warn!(error = ?e, "DAVE decryption failed");
+                                        Err(e) if body.ends_with(b"\xfa\xfa") => {
+                                            error!(error = ?e, "DAVE decryption failed");
+                                        },
+                                        _ => {
+                                            // Let packets that failed to decrypt but does not look like
+                                            // a DAVE frame to pass through normally.
                                         },
                                     }
                                 }

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -18,6 +18,8 @@ use discortp::{
     rtp::RtpPacket,
 };
 use flume::Receiver;
+use parking_lot::RwLock as PRwLock;
+use std::sync::atomic::AtomicU16;
 use std::{
     collections::{HashMap, HashSet},
     num::Wrapping,
@@ -39,6 +41,8 @@ struct UdpRx {
     rx: Receiver<UdpRxMessage>,
     ssrc_signalling: Arc<SsrcTracker>,
     udp_socket: UdpSocket,
+    dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    dave_protocol_version: Arc<AtomicU16>,
 }
 
 impl UdpRx {
@@ -253,6 +257,8 @@ pub(crate) async fn runner(
     config: Config,
     udp_socket: UdpSocket,
     ssrc_signalling: Arc<SsrcTracker>,
+    dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    dave_protocol_version: Arc<AtomicU16>,
 ) {
     trace!("UDP receive handle started.");
 
@@ -264,6 +270,8 @@ pub(crate) async fn runner(
         rx,
         ssrc_signalling,
         udp_socket,
+        dave_session,
+        dave_protocol_version,
     };
 
     state.run(&mut interconnect).await;

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -203,6 +203,9 @@ impl UdpRx {
                                             if padding_byte < body_length
                                                 && body[..body_length - padding_byte]
                                                     .ends_with(b"\xfa\xfa")
+                                                && body[body_length - padding_byte..]
+                                                    .iter()
+                                                    .all(|b| (*b as usize) == padding_byte)
                                             {
                                                 body = &mut body[..body_length - padding_byte];
                                             }

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -191,13 +191,19 @@ impl UdpRx {
                     let payload = rtp.payload_mut();
                     let payload_length = payload.len();
                     let body = &mut payload[rtp_body_start..payload_length - rtp_body_tail];
+                    let body_length = body.len();
 
-                    // If the packet is decrypted, DAVE is active, and the packet is actually
-                    // encrypted (magic marker 0xFAFA). Need to check for encryption because
-                    // davey spits out error logs if you feed it an unencrypted packet.
+                    // If the packet is transport-decrypted, DAVE is enabled, and the packet
+                    // looks encrypted: https://daveprotocol.com/#protocol-frame-check
+                    // The packet must be at least 11 bytes consisting of:
+                    // - 8 byte truncated AES128-GCM authentication tag
+                    // - 1 byte protocol supplemental data size
+                    // - 2 byte magic marker
                     if decrypted
                         && self.dave_protocol_version.load(Ordering::Relaxed) != 0
-                        && body.ends_with(b"\xfa\xfa")
+                        && body_length >= 11
+                        && body[body_length - DAVE_MAGIC_MARKER.len()..body_length]
+                            == DAVE_MAGIC_MARKER
                     {
                         // Silently drop encrypted packets if it's not possible to decrypt them for
                         // one reason or another; otherwise there'd be error logs for trying to decode

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -19,7 +19,6 @@ use discortp::{
     MutablePacket,
 };
 use flume::Receiver;
-use parking_lot::RwLock as PRwLock;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::{
     collections::{HashMap, HashSet},
@@ -27,7 +26,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{net::UdpSocket, select, time::Instant};
+use tokio::{net::UdpSocket, select, sync::RwLock, time::Instant};
 use tracing::{error, instrument, trace, warn};
 
 type RtpSequence = Wrapping<u16>;
@@ -42,7 +41,7 @@ struct UdpRx {
     rx: Receiver<UdpRxMessage>,
     ssrc_signalling: Arc<SsrcTracker>,
     udp_socket: UdpSocket,
-    dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
     dave_protocol_version: Arc<AtomicU16>,
 }
 
@@ -184,7 +183,7 @@ impl UdpRx {
                 // and we know who this voice packet came from
                 if let Some((rtp_body_start, rtp_body_tail, decrypted)) = packet_data {
                     if decrypted && self.dave_protocol_version.load(Ordering::Relaxed) != 0 {
-                        if let Some(ref mut dave_session) = *self.dave_session.write() {
+                        if let Some(ref mut dave_session) = *self.dave_session.blocking_write() {
                             if dave_session.is_ready() {
                                 if let Some(user_id) =
                                     self.ssrc_signalling.ssrc_user_map.get(&rtp.get_ssrc())
@@ -311,7 +310,7 @@ pub(crate) async fn runner(
     config: Config,
     udp_socket: UdpSocket,
     ssrc_signalling: Arc<SsrcTracker>,
-    dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
     dave_protocol_version: Arc<AtomicU16>,
 ) {
     trace!("UDP receive handle started.");

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -16,8 +16,8 @@ use bytes::BytesMut;
 use discortp::{
     demux::{self, DemuxedMut},
     rtp::RtpPacket,
-    MutablePacket,
 };
+use discortp::{MutablePacket, Packet};
 use flume::Receiver;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::{
@@ -164,11 +164,18 @@ impl UdpRx {
                     return;
                 }
 
-                let packet_data = if self.config.decode_mode.should_decrypt() {
-                    let out = self
-                        .cipher
-                        .decrypt_rtp_in_place(&mut rtp)
-                        .map(|(s, t)| (s, t, true));
+                let mut packet_data = if self.config.decode_mode.should_decrypt() {
+                    let out = self.cipher.decrypt_rtp_in_place(&mut rtp).map(|(s, t)| {
+                        if rtp.get_padding() != 0 {
+                            let payload = rtp.payload();
+                            let payload_length = payload.len();
+                            let padding_count = payload[payload_length - t - 1] as usize;
+
+                            (s, t + padding_count, true)
+                        } else {
+                            (s, t, true)
+                        }
+                    });
 
                     if let Err(ref e) = out {
                         warn!("RTP decryption failed: {:?}", e);
@@ -179,39 +186,22 @@ impl UdpRx {
                     None
                 };
 
-                // If transport encryption was decrypted, DAVE is used
-                // and we know who this voice packet came from
                 if let Some((rtp_body_start, rtp_body_tail, decrypted)) = packet_data {
-                    if decrypted && self.dave_protocol_version.load(Ordering::Relaxed) != 0 {
-                        if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                            if dave_session.is_ready() {
-                                if let Some(user_id) =
-                                    self.ssrc_signalling.ssrc_user_map.get(&rtp.get_ssrc())
-                                {
-                                    let payload = rtp.payload_mut();
-                                    let payload_length = payload.len();
-                                    let mut body = &mut payload
-                                        [rtp_body_start..payload_length - rtp_body_tail];
+                    let ssrc = rtp.get_ssrc();
+                    let payload = rtp.payload_mut();
+                    let payload_length = payload.len();
+                    let body = &mut payload[rtp_body_start..payload_length - rtp_body_tail];
 
-                                    // HACK: Discord sometimes include PKCS7 padding in the payload
-                                    // for no inexplicable reason. This doesn't consistently happen.
-                                    if !body.ends_with(b"\xfa\xfa") {
-                                        if let Some(padding_byte) = body.last().copied() {
-                                            let padding_byte = padding_byte as usize;
-                                            let body_length = body.len();
-
-                                            if padding_byte < body_length
-                                                && body[..body_length - padding_byte]
-                                                    .ends_with(b"\xfa\xfa")
-                                                && body[body_length - padding_byte..]
-                                                    .iter()
-                                                    .all(|b| (*b as usize) == padding_byte)
-                                            {
-                                                body = &mut body[..body_length - padding_byte];
-                                            }
-                                        }
-                                    }
-
+                    // If the packet is decrypted, DAVE is active, and the packet is actually
+                    // encrypted (magic marker 0xFAFA). Need to check for encryption because
+                    // davey spits out error logs if you feed it an unencrypted packet.
+                    if decrypted
+                        && self.dave_protocol_version.load(Ordering::Relaxed) != 0
+                        && body.ends_with(b"\xfa\xfa")
+                    {
+                        if let Some(user_id) = self.ssrc_signalling.ssrc_user_map.get(&ssrc) {
+                            if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                                if dave_session.is_ready() {
                                     let result = dave_session.decrypt(
                                         user_id.0,
                                         davey::MediaType::AUDIO,
@@ -219,16 +209,22 @@ impl UdpRx {
                                     );
 
                                     match result {
-                                        Ok(decrypted_payload) => {
-                                            body[..decrypted_payload.len()]
-                                                .copy_from_slice(&decrypted_payload);
+                                        Ok(decrypted_body) => {
+                                            packet_data = Some((
+                                                rtp_body_start,
+                                                rtp_body_tail + (body.len() - decrypted_body.len()),
+                                                decrypted,
+                                            ));
+                                            body[..decrypted_body.len()]
+                                                .copy_from_slice(&decrypted_body);
                                         },
-                                        Err(e) if body.ends_with(b"\xfa\xfa") => {
-                                            warn!(error = ?e, "DAVE decryption failed");
+                                        Err(davey::errors::DecryptError::NoDecryptorForUser) => {
+                                            // Silently drop encrypted packets for users whose ratchets are not configured yet.
+                                            return;
                                         },
-                                        _ => {
-                                            // Let packets that failed to decrypt but does not look like
-                                            // a DAVE frame to pass through normally.
+                                        Err(e) => {
+                                            error!(error = ?e, "DAVE decryption failed");
+                                            return;
                                         },
                                     }
                                 }

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -224,7 +224,7 @@ impl UdpRx {
                                                 .copy_from_slice(&decrypted_payload);
                                         },
                                         Err(e) if body.ends_with(b"\xfa\xfa") => {
-                                            error!(error = ?e, "DAVE decryption failed");
+                                            warn!(error = ?e, "DAVE decryption failed");
                                         },
                                         _ => {
                                             // Let packets that failed to decrypt but does not look like

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -19,14 +19,17 @@ use discortp::{
 };
 use discortp::{MutablePacket, Packet};
 use flume::Receiver;
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::{
+    atomic::{AtomicU16, Ordering},
+    RwLock,
+};
 use std::{
     collections::{HashMap, HashSet},
     num::Wrapping,
     sync::Arc,
     time::Duration,
 };
-use tokio::{net::UdpSocket, select, sync::RwLock, time::Instant};
+use tokio::{net::UdpSocket, select, time::Instant};
 use tracing::{error, instrument, trace, warn};
 
 type RtpSequence = Wrapping<u16>;
@@ -211,7 +214,7 @@ impl UdpRx {
                         let Some(user_id) = self.ssrc_signalling.ssrc_user_map.get(&ssrc) else {
                             return;
                         };
-                        let Some(ref mut dave_session) = *self.dave_session.write().await else {
+                        let Some(ref mut dave_session) = *self.dave_session.write().unwrap() else {
                             return;
                         };
 

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -199,36 +199,44 @@ impl UdpRx {
                         && self.dave_protocol_version.load(Ordering::Relaxed) != 0
                         && body.ends_with(b"\xfa\xfa")
                     {
-                        if let Some(user_id) = self.ssrc_signalling.ssrc_user_map.get(&ssrc) {
-                            if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                                if dave_session.is_ready() {
-                                    let result = dave_session.decrypt(
-                                        user_id.0,
-                                        davey::MediaType::AUDIO,
-                                        body,
-                                    );
+                        // Silently drop encrypted packets if it's not possible to decrypt them for
+                        // one reason or another; otherwise there'd be error logs for trying to decode
+                        // Opus
+                        let Some(user_id) = self.ssrc_signalling.ssrc_user_map.get(&ssrc) else {
+                            return;
+                        };
+                        let Some(ref mut dave_session) = *self.dave_session.write().await else {
+                            return;
+                        };
 
-                                    match result {
-                                        Ok(decrypted_body) => {
-                                            packet_data = Some((
-                                                rtp_body_start,
-                                                rtp_body_tail + (body.len() - decrypted_body.len()),
-                                                decrypted,
-                                            ));
-                                            body[..decrypted_body.len()]
-                                                .copy_from_slice(&decrypted_body);
-                                        },
-                                        Err(davey::errors::DecryptError::NoDecryptorForUser) => {
-                                            // Silently drop encrypted packets for users whose ratchets are not configured yet.
-                                            return;
-                                        },
-                                        Err(e) => {
-                                            error!(error = ?e, "DAVE decryption failed");
-                                            return;
-                                        },
-                                    }
-                                }
-                            }
+                        if !dave_session.is_ready() {
+                            return;
+                        }
+
+                        let result = dave_session.decrypt(user_id.0, davey::MediaType::AUDIO, body);
+
+                        match result {
+                            Ok(decrypted_body) => {
+                                packet_data = Some((
+                                    rtp_body_start,
+                                    rtp_body_tail + (body.len() - decrypted_body.len()),
+                                    decrypted,
+                                ));
+                                body[..decrypted_body.len()].copy_from_slice(&decrypted_body);
+                            },
+                            Err(davey::errors::DecryptError::NoDecryptorForUser)
+                            | Err(davey::errors::DecryptError::DecryptionFailed(
+                                davey::errors::DecryptorDecryptError::NoValidCryptorFound {
+                                    ..
+                                },
+                            )) => {
+                                // Silently drop encrypted packets for users whose ratchets are not configured yet.
+                                return;
+                            },
+                            Err(e) => {
+                                error!(error = ?e, "DAVE decryption failed");
+                                return;
+                            },
                         }
                     }
                 }

--- a/src/driver/tasks/udp_rx/mod.rs
+++ b/src/driver/tasks/udp_rx/mod.rs
@@ -16,10 +16,11 @@ use bytes::BytesMut;
 use discortp::{
     demux::{self, DemuxedMut},
     rtp::RtpPacket,
+    MutablePacket,
 };
 use flume::Receiver;
 use parking_lot::RwLock as PRwLock;
-use std::sync::atomic::AtomicU16;
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::{
     collections::{HashMap, HashSet},
     num::Wrapping,
@@ -126,6 +127,8 @@ impl UdpRx {
 
                         _ = self.ssrc_signalling.disconnected_users.remove(&id);
                         if let Some((_, ssrc)) = self.ssrc_signalling.user_ssrc_map.remove(&id) {
+                            let _ = self.ssrc_signalling.ssrc_user_map.remove(&ssrc);
+
                             if let Some(state) = self.decoder_map.get_mut(&ssrc) {
                                 // don't cleanup immediately: leave for later cycle
                                 // this is key with reorder/jitter buffers where we may
@@ -176,6 +179,57 @@ impl UdpRx {
                 } else {
                     None
                 };
+
+                // If transport encryption was decrypted, DAVE is used
+                // and we know who this voice packet came from
+                if let Some((rtp_body_start, rtp_body_tail, decrypted)) = packet_data {
+                    if decrypted && self.dave_protocol_version.load(Ordering::Relaxed) != 0 {
+                        if let Some(ref mut dave_session) = *self.dave_session.write() {
+                            if dave_session.is_ready() {
+                                if let Some(user_id) =
+                                    self.ssrc_signalling.ssrc_user_map.get(&rtp.get_ssrc())
+                                {
+                                    let payload = rtp.payload_mut();
+                                    let payload_length = payload.len();
+                                    let mut body = &mut payload
+                                        [rtp_body_start..payload_length - rtp_body_tail];
+
+                                    // HACK: Discord sometimes include PKCS7 padding in the payload
+                                    // for no inexplicable reason. This doesn't consistently happen.
+                                    if !body.ends_with(b"\xfa\xfa") {
+                                        if let Some(padding_byte) = body.last().copied() {
+                                            let padding_byte = padding_byte as usize;
+                                            let body_length = body.len();
+
+                                            if padding_byte < body_length
+                                                && body[..body_length - padding_byte]
+                                                    .ends_with(b"\xfa\xfa")
+                                            {
+                                                body = &mut body[..body_length - padding_byte];
+                                            }
+                                        }
+                                    }
+
+                                    let result = dave_session.decrypt(
+                                        user_id.0,
+                                        davey::MediaType::AUDIO,
+                                        body,
+                                    );
+
+                                    match result {
+                                        Ok(decrypted_payload) => {
+                                            body[..decrypted_payload.len()]
+                                                .copy_from_slice(&decrypted_payload);
+                                        },
+                                        Err(e) => {
+                                            warn!(error = ?e, "DAVE decryption failed");
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 let rtp = rtp.to_immutable();
                 let (rtp_body_start, rtp_body_tail, decrypted) = packet_data.unwrap_or_else(|| {

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -111,6 +111,12 @@ impl AuxNetwork {
             let hb = sleep_until(next_heartbeat);
 
             select! {
+                // Biased polling (polling from top to bottom) is needed to process WebSocket events
+                // queued in the initial handshake (messages before SessionDescription). One of the
+                // events queued is ClientsConnect, which is needed to correctly keep track of
+                // recognized_user_ids and to correctly process DaveMlsProposals.
+                biased;
+
                 () = hb => {
                     ws_error = match self.send_heartbeat().await {
                         Err(e) => {
@@ -121,26 +127,6 @@ impl AuxNetwork {
                         _ => false,
                     };
                     next_heartbeat = self.next_heartbeat();
-                }
-                ws_msg = self.ws_client.recv_event_no_timeout(), if !self.dont_send => {
-                    ws_error = match ws_msg {
-                        Err(e) => {
-                            should_reconnect = ws_error_is_not_final(&e);
-                            ws_reason = Some((&e).into());
-                            true
-                        },
-                        Ok(Some(msg)) => {
-                            match self.process_ws(interconnect, msg).await {
-                                Err(e) => {
-                                    should_reconnect = ws_error_is_not_final(&e);
-                                    ws_reason = Some((&e).into());
-                                    true
-                                },
-                                _ => false
-                            }
-                        },
-                        _ => false,
-                    };
                 }
                 inner_msg = self.rx.recv_async() => {
                     match inner_msg {
@@ -194,6 +180,26 @@ impl AuxNetwork {
                             break;
                         },
                     }
+                }
+                ws_msg = self.ws_client.recv_event_no_timeout(), if !self.dont_send => {
+                    ws_error = match ws_msg {
+                        Err(e) => {
+                            should_reconnect = ws_error_is_not_final(&e);
+                            ws_reason = Some((&e).into());
+                            true
+                        },
+                        Ok(Some(msg)) => {
+                            match self.process_ws(interconnect, msg).await {
+                                Err(e) => {
+                                    should_reconnect = ws_error_is_not_final(&e);
+                                    ws_reason = Some((&e).into());
+                                    true
+                                },
+                                _ => false
+                            }
+                        },
+                        _ => false,
+                    };
                 }
             }
 

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -318,8 +318,12 @@ impl AuxNetwork {
             GatewayEvent::DavePrepareEpoch(ev) if ev.epoch == 1 => {
                 self.dave_protocol_version
                     .store(ev.protocol_version, Ordering::Relaxed);
-                if let Err(e) = self.reinit_dave_session().await {
-                    warn!(error = ?e, "failed to reinitialize DAVE session");
+                match self.reinit_dave_session().await {
+                    Err(DaveReinitError::Ws(e)) => return Err(e),
+                    Err(e) => {
+                        warn!(error = ?e, "failed to reinitialize DAVE session");
+                    },
+                    _ => {},
                 }
             },
             GatewayEvent::DaveMlsExternalSender(ev) => {
@@ -389,8 +393,12 @@ impl AuxNetwork {
                                 transition_id: ev.transition_id,
                             }))
                             .await?;
-                        if let Err(e) = self.reinit_dave_session().await {
-                            warn!(error = ?e, "failed to reinitialize DAVE session");
+                        match self.reinit_dave_session().await {
+                            Err(DaveReinitError::Ws(e)) => return Err(e),
+                            Err(e) => {
+                                warn!(error = ?e, "failed to reinitialize DAVE session");
+                            },
+                            _ => {},
                         }
                     },
                     None => {},
@@ -420,8 +428,12 @@ impl AuxNetwork {
                                 transition_id: ev.transition_id,
                             }))
                             .await?;
-                        if let Err(e) = self.reinit_dave_session().await {
-                            warn!(error = ?e, "failed to reinitialize DAVE session");
+                        match self.reinit_dave_session().await {
+                            Err(DaveReinitError::Ws(e)) => return Err(e),
+                            Err(e) => {
+                                warn!(error = ?e, "failed to reinitialize DAVE session");
+                            },
+                            _ => {},
                         }
                     },
                     None => {},

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -10,7 +10,6 @@ use crate::{
     ConnectionInfo,
 };
 use flume::Receiver;
-use parking_lot::RwLock as PRwLock;
 use rand::{distr::Uniform, Rng};
 use serenity_voice_model::payload::{
     DaveMlsCommitWelcome, DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage,
@@ -27,6 +26,7 @@ use std::{
 };
 use tokio::{
     select,
+    sync::RwLock,
     time::{sleep_until, Instant},
 };
 #[cfg(feature = "tungstenite")]
@@ -47,7 +47,7 @@ pub(crate) struct AuxNetwork {
     attempt_idx: usize,
     info: ConnectionInfo,
 
-    dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
     dave_protocol_version: Arc<AtomicU16>,
     dave_pending_transitions: HashMap<u16, u16>,
     dave_downgraded: bool,
@@ -64,7 +64,7 @@ impl AuxNetwork {
         heartbeat_interval: f64,
         attempt_idx: usize,
         info: ConnectionInfo,
-        dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+        dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
         dave_protocol_version: Arc<AtomicU16>,
         #[cfg(feature = "receive")] ssrc_signalling: Arc<SsrcTracker>,
     ) -> Self {
@@ -281,7 +281,7 @@ impl AuxNetwork {
                     self.execute_dave_transition(ev.transition_id).await;
                 } else {
                     if ev.protocol_version == 0 {
-                        if let Some(ref mut dave_session) = *self.dave_session.write() {
+                        if let Some(ref mut dave_session) = *self.dave_session.write().await {
                             dave_session.set_passthrough_mode(true, Some(120));
                         }
 
@@ -305,7 +305,7 @@ impl AuxNetwork {
                 }
             },
             GatewayEvent::DaveMlsExternalSender(ev) => {
-                if let Some(ref mut dave_session) = *self.dave_session.write() {
+                if let Some(ref mut dave_session) = *self.dave_session.write().await {
                     if let Err(e) = dave_session.set_external_sender(&ev.external_sender) {
                         warn!(error = ?e, "error setting MLS external sender");
                     }
@@ -316,7 +316,7 @@ impl AuxNetwork {
                     DaveMlsProposalsOperationType::Append => davey::ProposalsOperationType::APPEND,
                     DaveMlsProposalsOperationType::Revoke => davey::ProposalsOperationType::REVOKE,
                 };
-                let result = if let Some(ref mut dave_session) = *self.dave_session.write() {
+                let result = if let Some(ref mut dave_session) = *self.dave_session.write().await {
                     match dave_session.process_proposals(operation_type, &ev.proposals, None) {
                         Ok(result) => result,
                         Err(e) => {
@@ -338,7 +338,7 @@ impl AuxNetwork {
                 }
             },
             GatewayEvent::DaveMlsAnnounceCommitTransition(ev) => {
-                match self.dave_process_commit(&ev.commit_message) {
+                match self.dave_process_commit(&ev.commit_message).await {
                     Some(Ok(_)) => {
                         if ev.transition_id != 0 {
                             let protocol_version =
@@ -369,7 +369,7 @@ impl AuxNetwork {
                 };
             },
             GatewayEvent::DaveMlsWelcome(ev) => {
-                if let Some(Err(e)) = self.dave_process_welcome(&ev.welcome) {
+                if let Some(Err(e)) = self.dave_process_welcome(&ev.welcome).await {
                     warn!("MLS welcome errored: {e:?}");
                     self.ws_client
                         .send_json(&GatewayEvent::from(DaveMlsInvalidCommitWelcome {
@@ -389,22 +389,22 @@ impl AuxNetwork {
         Ok(())
     }
 
-    fn dave_process_commit(
+    async fn dave_process_commit(
         &mut self,
         commit_message: &[u8],
     ) -> Option<Result<(), davey::errors::ProcessCommitError>> {
-        let Some(ref mut dave_session) = *self.dave_session.write() else {
+        let Some(ref mut dave_session) = *self.dave_session.write().await else {
             return None;
         };
 
         Some(dave_session.process_commit(commit_message))
     }
 
-    fn dave_process_welcome(
+    async fn dave_process_welcome(
         &mut self,
         welcome: &[u8],
     ) -> Option<Result<(), davey::errors::ProcessWelcomeError>> {
-        let Some(ref mut dave_session) = *self.dave_session.write() else {
+        let Some(ref mut dave_session) = *self.dave_session.write().await else {
             return None;
         };
 
@@ -423,7 +423,7 @@ impl AuxNetwork {
                 .0
                 .into();
 
-            let key_package = if let Some(ref mut dave_session) = *self.dave_session.write() {
+            let key_package = if let Some(ref mut dave_session) = *self.dave_session.write().await {
                 dave_session.reinit(dave_protocol_version, user_id, channel_id, None)?;
                 dave_session.create_key_package()?
             } else {
@@ -431,7 +431,7 @@ impl AuxNetwork {
                     davey::DaveSession::new(dave_protocol_version, user_id, channel_id, None)?;
                 let key_package = dave_session.create_key_package()?;
 
-                *self.dave_session.write() = Some(dave_session);
+                *self.dave_session.write().await = Some(dave_session);
 
                 key_package
             };
@@ -441,7 +441,7 @@ impl AuxNetwork {
                     key_package,
                 }))
                 .await?;
-        } else if let Some(ref mut dave_session) = *self.dave_session.write() {
+        } else if let Some(ref mut dave_session) = *self.dave_session.write().await {
             dave_session.reset()?;
             dave_session.set_passthrough_mode(true, Some(10));
         }
@@ -464,7 +464,7 @@ impl AuxNetwork {
         } else if transition_id > 0 && self.dave_downgraded {
             self.dave_downgraded = false;
 
-            if let Some(ref mut dave_session) = *self.dave_session.write() {
+            if let Some(ref mut dave_session) = *self.dave_session.write().await {
                 dave_session.set_passthrough_mode(true, Some(10));
             }
         }

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -11,12 +11,15 @@ use crate::{
 };
 use flume::Receiver;
 use rand::{distr::Uniform, Rng};
-use serenity_voice_model::payload::{
-    DaveMlsCommitWelcome, DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage,
-    DaveMlsProposalsOperationType, DaveTransitionReady,
+use serenity_voice_model::{
+    id::UserId,
+    payload::{
+        DaveMlsCommitWelcome, DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage,
+        DaveMlsProposalsOperationType, DaveTransitionReady,
+    },
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     num::NonZeroU16,
     sync::{
         atomic::{AtomicU16, Ordering},
@@ -50,7 +53,7 @@ pub(crate) struct AuxNetwork {
     dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
     dave_protocol_version: Arc<AtomicU16>,
     dave_pending_transitions: HashMap<u16, u16>,
-    dave_downgraded: bool,
+    recognized_user_ids: HashSet<UserId>,
 
     #[cfg(feature = "receive")]
     ssrc_signalling: Arc<SsrcTracker>,
@@ -68,6 +71,10 @@ impl AuxNetwork {
         dave_protocol_version: Arc<AtomicU16>,
         #[cfg(feature = "receive")] ssrc_signalling: Arc<SsrcTracker>,
     ) -> Self {
+        let mut recognized_user_ids = HashSet::new();
+
+        recognized_user_ids.insert(info.user_id.into());
+
         Self {
             rx: evt_rx,
             ws_client,
@@ -85,7 +92,7 @@ impl AuxNetwork {
             dave_session,
             dave_protocol_version,
             dave_pending_transitions: HashMap::new(),
-            dave_downgraded: false,
+            recognized_user_ids,
 
             #[cfg(feature = "receive")]
             ssrc_signalling,
@@ -257,9 +264,14 @@ impl AuxNetwork {
                     self.ssrc_signalling.disconnected_users.insert(ev.user_id);
                 }
 
+                self.recognized_user_ids.remove(&ev.user_id);
+
                 drop(interconnect.events.send(EventMessage::FireCoreEvent(
                     CoreContext::ClientDisconnect(ev),
                 )));
+            },
+            GatewayEvent::ClientsConnect(ev) => {
+                self.recognized_user_ids.extend(&ev.user_ids);
             },
             GatewayEvent::HeartbeatAck(ev) => {
                 if let Some(nonce) = self.last_heartbeat_nonce.take() {
@@ -317,7 +329,17 @@ impl AuxNetwork {
                     DaveMlsProposalsOperationType::Revoke => davey::ProposalsOperationType::REVOKE,
                 };
                 let result = if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                    match dave_session.process_proposals(operation_type, &ev.proposals, None) {
+                    match dave_session.process_proposals(
+                        operation_type,
+                        &ev.proposals,
+                        Some(
+                            &self
+                                .recognized_user_ids
+                                .iter()
+                                .map(|u| u.0)
+                                .collect::<Vec<_>>(),
+                        ),
+                    ) {
                         Ok(result) => result,
                         Err(e) => {
                             warn!(error = ?e, "error processing MLS proposals");
@@ -450,20 +472,17 @@ impl AuxNetwork {
     }
 
     async fn execute_dave_transition(&mut self, transition_id: u16) {
-        let Some(new_version) = self.dave_pending_transitions.get(&transition_id) else {
+        let Some(new_version) = self.dave_pending_transitions.get(&transition_id).copied() else {
             warn!("Received DaveExecuteTransition for unknown transition ID {transition_id}");
             return;
         };
         let old_version = self.dave_protocol_version.load(Ordering::Relaxed);
 
         self.dave_protocol_version
-            .store(*new_version, Ordering::Relaxed);
+            .store(new_version, Ordering::Relaxed);
 
-        if old_version != *new_version && *new_version == 0 {
-            self.dave_downgraded = true;
-        } else if transition_id > 0 && self.dave_downgraded {
-            self.dave_downgraded = false;
-
+        // Upgraded from transport-only encryption
+        if transition_id > 0 && old_version == 0 && new_version != 0 {
             if let Some(ref mut dave_session) = *self.dave_session.write().await {
                 dave_session.set_passthrough_mode(true, Some(10));
             }

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -3,21 +3,23 @@ use crate::{
     events::CoreContext,
     model::{
         payload::{Heartbeat, Speaking},
-        CloseCode as VoiceCloseCode,
-        Event as GatewayEvent,
-        FromPrimitive,
-        SpeakingState,
+        CloseCode as VoiceCloseCode, Event as GatewayEvent, FromPrimitive, SpeakingState,
     },
     ws::{Error as WsError, WsStream},
     ConnectionInfo,
 };
 use flume::Receiver;
 use rand::{distr::Uniform, Rng};
+use serenity_voice_model::payload::{
+    DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage, DaveMlsProposalsOperationType,
+    DaveTransitionReady,
+};
 #[cfg(feature = "receive")]
 use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashMap, num::NonZeroU16, sync::Arc, time::Duration};
 use tokio::{
     select,
+    sync::RwLock,
     time::{sleep_until, Instant},
 };
 #[cfg(feature = "tungstenite")]
@@ -38,6 +40,11 @@ pub(crate) struct AuxNetwork {
     attempt_idx: usize,
     info: ConnectionInfo,
 
+    dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
+    dave_protocol_version: Option<NonZeroU16>,
+    dave_pending_transitions: HashMap<u16, u16>,
+    dave_downgraded: bool,
+
     #[cfg(feature = "receive")]
     ssrc_signalling: Arc<SsrcTracker>,
 }
@@ -50,6 +57,8 @@ impl AuxNetwork {
         heartbeat_interval: f64,
         attempt_idx: usize,
         info: ConnectionInfo,
+        dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
+        dave_protocol_version: Option<NonZeroU16>,
         #[cfg(feature = "receive")] ssrc_signalling: Arc<SsrcTracker>,
     ) -> Self {
         Self {
@@ -65,6 +74,11 @@ impl AuxNetwork {
 
             attempt_idx,
             info,
+
+            dave_session,
+            dave_protocol_version,
+            dave_pending_transitions: HashMap::new(),
+            dave_downgraded: false,
 
             #[cfg(feature = "receive")]
             ssrc_signalling,
@@ -94,7 +108,7 @@ impl AuxNetwork {
                     };
                     next_heartbeat = self.next_heartbeat();
                 }
-                ws_msg = self.ws_client.recv_json_no_timeout(), if !self.dont_send => {
+                ws_msg = self.ws_client.recv_event_no_timeout(), if !self.dont_send => {
                     ws_error = match ws_msg {
                         Err(e) => {
                             should_reconnect = ws_error_is_not_final(&e);
@@ -102,7 +116,7 @@ impl AuxNetwork {
                             true
                         },
                         Ok(Some(msg)) => {
-                            self.process_ws(interconnect, msg);
+                            self.process_ws(interconnect, msg).await.expect("TODO");
                             false
                         },
                         _ => false,
@@ -147,7 +161,7 @@ impl AuxNetwork {
                             }
                         },
                         Ok(WsMessage::Deliver(msg)) => {
-                            self.process_ws(interconnect, msg);
+                            self.process_ws(interconnect, msg).await.expect("TODO");
                         },
                         Err(flume::RecvError::Disconnected) => {
                             break;
@@ -197,7 +211,11 @@ impl AuxNetwork {
         Ok(())
     }
 
-    fn process_ws(&mut self, interconnect: &Interconnect, value: GatewayEvent) {
+    async fn process_ws(
+        &mut self,
+        interconnect: &Interconnect,
+        value: GatewayEvent,
+    ) -> Result<(), WsError> {
         match value {
             GatewayEvent::Speaking(ev) => {
                 #[cfg(feature = "receive")]
@@ -234,10 +252,180 @@ impl AuxNetwork {
                     }
                 }
             },
+            GatewayEvent::DavePrepareTransition(ev) => {
+                self.dave_pending_transitions
+                    .insert(ev.transition_id, ev.protocol_version);
+
+                if ev.transition_id == 0 {
+                    self.execute_dave_transition(ev.transition_id).await;
+                } else {
+                    if ev.protocol_version == 0 {
+                        if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                            dave_session.set_passthrough_mode(true, Some(120));
+                        }
+
+                        self.ws_client
+                            .send_json(&GatewayEvent::DaveTransitionReady(DaveTransitionReady {
+                                transition_id: ev.transition_id,
+                                protocol_version: ev.protocol_version,
+                            }))
+                            .await?;
+                    }
+                }
+            },
+            GatewayEvent::DaveExecuteTransition(ev) => {
+                self.execute_dave_transition(ev.transition_id).await;
+            },
+            GatewayEvent::DavePrepareEpoch(ev) if ev.epoch == 1 => {
+                self.dave_protocol_version = NonZeroU16::new(ev.protocol_version);
+                self.reinit_dave_session().await;
+            },
+            GatewayEvent::DaveMlsExternalSender(ev) => {
+                if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                    dave_session
+                        .set_external_sender(&ev.external_sender)
+                        .expect("TODO");
+                }
+            },
+            GatewayEvent::DaveMlsProposals(ev) => {
+                let operation_type = match ev.operation_type {
+                    DaveMlsProposalsOperationType::Append => davey::ProposalsOperationType::APPEND,
+                    DaveMlsProposalsOperationType::Revoke => davey::ProposalsOperationType::REVOKE,
+                };
+                if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                    dave_session
+                        .process_proposals(operation_type, &ev.proposals, None)
+                        .expect("TODO");
+                }
+            },
+            GatewayEvent::DaveMlsAnnounceCommitTransition(ev) => {
+                let mut lock = self.dave_session.write().await;
+
+                if let Some(ref mut dave_session) = *lock {
+                    match dave_session.process_commit(&ev.commit_message) {
+                        Ok(_) => {
+                            if ev.transition_id != 0 {
+                                self.dave_pending_transitions.insert(
+                                    ev.transition_id,
+                                    dave_session.protocol_version().into(),
+                                );
+                                self.ws_client
+                                    .send_json(&GatewayEvent::DaveTransitionReady(
+                                        DaveTransitionReady {
+                                            transition_id: ev.transition_id,
+                                            protocol_version: dave_session
+                                                .protocol_version()
+                                                .into(),
+                                        },
+                                    ))
+                                    .await?;
+                            }
+                        },
+                        Err(e) => {
+                            warn!("MLS commit errored: {e:?}");
+                            self.ws_client
+                                .send_json(&GatewayEvent::DaveMlsInvalidCommitWelcome(
+                                    DaveMlsInvalidCommitWelcome {
+                                        transition_id: ev.transition_id,
+                                    },
+                                ))
+                                .await?;
+                            drop(lock);
+                            self.reinit_dave_session().await;
+                        },
+                    }
+                }
+            },
+            GatewayEvent::DaveMlsWelcome(ev) => {
+                let mut lock = self.dave_session.write().await;
+
+                if let Some(ref mut dave_session) = *lock {
+                    match dave_session.process_welcome(&ev.welcome) {
+                        Ok(_) => {},
+                        Err(e) => {
+                            warn!("MLS welcome errored: {e:?}");
+                            self.ws_client
+                                .send_json(&GatewayEvent::DaveMlsInvalidCommitWelcome(
+                                    DaveMlsInvalidCommitWelcome {
+                                        transition_id: ev.transition_id,
+                                    },
+                                ))
+                                .await?;
+                            drop(lock);
+                            self.reinit_dave_session().await;
+                        },
+                    }
+                }
+            },
             other => {
                 trace!("Received other websocket data: {:?}", other);
             },
         }
+
+        Ok(())
+    }
+
+    async fn reinit_dave_session(&mut self) {
+        if let Some(dave_protocol_version) = self.dave_protocol_version {
+            let key_package = if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                dave_session
+                    .reinit(
+                        dave_protocol_version,
+                        self.info.user_id.0.into(),
+                        self.info.channel_id.expect("TODO").0.into(),
+                        None,
+                    )
+                    .expect("TODO");
+                dave_session.create_key_package().expect("TODO")
+            } else {
+                let mut dave_session = davey::DaveSession::new(
+                    dave_protocol_version,
+                    self.info.user_id.0.into(),
+                    self.info.channel_id.expect("TODO").0.into(),
+                    None,
+                )
+                .expect("TODO");
+                let key_package = dave_session.create_key_package().expect("TODO");
+
+                *self.dave_session.write().await = Some(dave_session);
+
+                key_package
+            };
+
+            self.ws_client
+                .send_binary(&GatewayEvent::DaveMlsKeyPackage(DaveMlsKeyPackage {
+                    key_package,
+                }))
+                .await
+                .expect("TODO");
+        } else if let Some(ref mut dave_session) = *self.dave_session.write().await {
+            dave_session.reset().expect("TODO");
+            dave_session.set_passthrough_mode(true, Some(10));
+        }
+    }
+
+    async fn execute_dave_transition(&mut self, transition_id: u16) {
+        let Some(new_version) = self.dave_pending_transitions.get(&transition_id) else {
+            warn!("Received DaveExecuteTransition for unknown transition ID {transition_id}");
+            return;
+        };
+        let old_version = if let Some(ref dave_session) = *self.dave_session.read().await {
+            dave_session.protocol_version().into()
+        } else {
+            0u16
+        };
+
+        if old_version != *new_version && *new_version == 0 {
+            self.dave_downgraded = true;
+        } else if transition_id > 0 && self.dave_downgraded {
+            self.dave_downgraded = false;
+
+            if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                dave_session.set_passthrough_mode(true, Some(10));
+            }
+        }
+
+        self.dave_pending_transitions.remove(&transition_id);
     }
 }
 
@@ -252,22 +440,24 @@ fn ws_error_is_not_final(err: &WsError) -> bool {
     match err {
         #[cfg(feature = "tungstenite")]
         WsError::WsClosed(Some(frame)) => match frame.code {
-            CloseCode::Library(l) =>
+            CloseCode::Library(l) => {
                 if let Some(code) = VoiceCloseCode::from_u16(l) {
                     code.should_resume()
                 } else {
                     true
-                },
+                }
+            },
             _ => true,
         },
         #[cfg(feature = "tws")]
         WsError::WsClosed(Some(code)) => match (*code).into() {
-            code @ 4000..=4999_u16 =>
+            code @ 4000..=4999_u16 => {
                 if let Some(code) = VoiceCloseCode::from_u16(code) {
                     code.should_resume()
                 } else {
                     true
-                },
+                }
+            },
             _ => true,
         },
         e => {

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -303,19 +303,17 @@ impl AuxNetwork {
 
                 if ev.transition_id == 0 {
                     self.execute_dave_transition(ev.transition_id).await;
-                } else {
-                    if ev.protocol_version == 0 {
-                        if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                            dave_session.set_passthrough_mode(true, Some(120));
-                        }
-
-                        self.ws_client
-                            .send_json(&GatewayEvent::from(DaveTransitionReady {
-                                transition_id: ev.transition_id,
-                                protocol_version: ev.protocol_version,
-                            }))
-                            .await?;
+                } else if ev.protocol_version == 0 {
+                    if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                        dave_session.set_passthrough_mode(true, Some(120));
                     }
+
+                    self.ws_client
+                        .send_json(&GatewayEvent::from(DaveTransitionReady {
+                            transition_id: ev.transition_id,
+                            protocol_version: ev.protocol_version,
+                        }))
+                        .await?;
                 }
             },
             GatewayEvent::DaveExecuteTransition(ev) => {
@@ -377,7 +375,7 @@ impl AuxNetwork {
             },
             GatewayEvent::DaveMlsAnnounceCommitTransition(ev) => {
                 match self.dave_process_commit(&ev.commit_message).await {
-                    Some(Ok(_)) =>
+                    Some(Ok(())) =>
                         if ev.transition_id != 0 {
                             let protocol_version =
                                 self.dave_protocol_version.load(Ordering::Relaxed);
@@ -411,7 +409,7 @@ impl AuxNetwork {
             },
             GatewayEvent::DaveMlsWelcome(ev) =>
                 match self.dave_process_welcome(&ev.welcome).await {
-                    Some(Ok(_)) =>
+                    Some(Ok(())) =>
                         if ev.transition_id != 0 {
                             let protocol_version =
                                 self.dave_protocol_version.load(Ordering::Relaxed);

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -391,16 +391,34 @@ impl AuxNetwork {
                 };
             },
             GatewayEvent::DaveMlsWelcome(ev) => {
-                if let Some(Err(e)) = self.dave_process_welcome(&ev.welcome).await {
-                    warn!("MLS welcome errored: {e:?}");
-                    self.ws_client
-                        .send_json(&GatewayEvent::from(DaveMlsInvalidCommitWelcome {
-                            transition_id: ev.transition_id,
-                        }))
-                        .await?;
-                    if let Err(e) = self.reinit_dave_session().await {
-                        warn!(error = ?e, "failed to reinitialize DAVE session");
-                    }
+                match self.dave_process_welcome(&ev.welcome).await {
+                    Some(Ok(_)) => {
+                        if ev.transition_id != 0 {
+                            let protocol_version =
+                                self.dave_protocol_version.load(Ordering::Relaxed);
+
+                            self.dave_pending_transitions
+                                .insert(ev.transition_id, protocol_version);
+                            self.ws_client
+                                .send_json(&GatewayEvent::from(DaveTransitionReady {
+                                    transition_id: ev.transition_id,
+                                    protocol_version,
+                                }))
+                                .await?;
+                        }
+                    },
+                    Some(Err(e)) => {
+                        warn!("MLS welcome errored: {e:?}");
+                        self.ws_client
+                            .send_json(&GatewayEvent::from(DaveMlsInvalidCommitWelcome {
+                                transition_id: ev.transition_id,
+                            }))
+                            .await?;
+                        if let Err(e) = self.reinit_dave_session().await {
+                            warn!(error = ?e, "failed to reinitialize DAVE session");
+                        }
+                    },
+                    None => {},
                 }
             },
             other => {

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -1,5 +1,6 @@
 use super::message::*;
 use crate::{
+    driver::tasks::error::DaveReinitError,
     events::CoreContext,
     model::{
         payload::{Heartbeat, Speaking},
@@ -9,17 +10,23 @@ use crate::{
     ConnectionInfo,
 };
 use flume::Receiver;
+use parking_lot::RwLock as PRwLock;
 use rand::{distr::Uniform, Rng};
 use serenity_voice_model::payload::{
-    DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage, DaveMlsProposalsOperationType,
-    DaveTransitionReady,
+    DaveMlsCommitWelcome, DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage,
+    DaveMlsProposalsOperationType, DaveTransitionReady,
 };
-#[cfg(feature = "receive")]
-use std::sync::Arc;
-use std::{collections::HashMap, num::NonZeroU16, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    num::NonZeroU16,
+    sync::{
+        atomic::{AtomicU16, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tokio::{
     select,
-    sync::RwLock,
     time::{sleep_until, Instant},
 };
 #[cfg(feature = "tungstenite")]
@@ -40,8 +47,8 @@ pub(crate) struct AuxNetwork {
     attempt_idx: usize,
     info: ConnectionInfo,
 
-    dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
-    dave_protocol_version: Option<NonZeroU16>,
+    dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+    dave_protocol_version: Arc<AtomicU16>,
     dave_pending_transitions: HashMap<u16, u16>,
     dave_downgraded: bool,
 
@@ -57,8 +64,8 @@ impl AuxNetwork {
         heartbeat_interval: f64,
         attempt_idx: usize,
         info: ConnectionInfo,
-        dave_session: Arc<RwLock<Option<davey::DaveSession>>>,
-        dave_protocol_version: Option<NonZeroU16>,
+        dave_session: Arc<PRwLock<Option<davey::DaveSession>>>,
+        dave_protocol_version: Arc<AtomicU16>,
         #[cfg(feature = "receive")] ssrc_signalling: Arc<SsrcTracker>,
     ) -> Self {
         Self {
@@ -116,8 +123,14 @@ impl AuxNetwork {
                             true
                         },
                         Ok(Some(msg)) => {
-                            self.process_ws(interconnect, msg).await.expect("TODO");
-                            false
+                            match self.process_ws(interconnect, msg).await {
+                                Err(e) => {
+                                    should_reconnect = ws_error_is_not_final(&e);
+                                    ws_reason = Some((&e).into());
+                                    true
+                                },
+                                _ => false
+                            }
                         },
                         _ => false,
                     };
@@ -161,7 +174,14 @@ impl AuxNetwork {
                             }
                         },
                         Ok(WsMessage::Deliver(msg)) => {
-                            self.process_ws(interconnect, msg).await.expect("TODO");
+                            ws_error |= match self.process_ws(interconnect, msg).await {
+                                Err(e) => {
+                                    should_reconnect = ws_error_is_not_final(&e);
+                                    ws_reason = Some((&e).into());
+                                    true
+                                }
+                                _ => false,
+                            }
                         },
                         Err(flume::RecvError::Disconnected) => {
                             break;
@@ -260,12 +280,12 @@ impl AuxNetwork {
                     self.execute_dave_transition(ev.transition_id).await;
                 } else {
                     if ev.protocol_version == 0 {
-                        if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                        if let Some(ref mut dave_session) = *self.dave_session.write() {
                             dave_session.set_passthrough_mode(true, Some(120));
                         }
 
                         self.ws_client
-                            .send_json(&GatewayEvent::DaveTransitionReady(DaveTransitionReady {
+                            .send_json(&GatewayEvent::from(DaveTransitionReady {
                                 transition_id: ev.transition_id,
                                 protocol_version: ev.protocol_version,
                             }))
@@ -277,14 +297,15 @@ impl AuxNetwork {
                 self.execute_dave_transition(ev.transition_id).await;
             },
             GatewayEvent::DavePrepareEpoch(ev) if ev.epoch == 1 => {
-                self.dave_protocol_version = NonZeroU16::new(ev.protocol_version);
+                self.dave_protocol_version
+                    .store(ev.protocol_version, Ordering::Relaxed);
                 self.reinit_dave_session().await;
             },
             GatewayEvent::DaveMlsExternalSender(ev) => {
-                if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                    dave_session
-                        .set_external_sender(&ev.external_sender)
-                        .expect("TODO");
+                if let Some(ref mut dave_session) = *self.dave_session.write() {
+                    if let Err(e) = dave_session.set_external_sender(&ev.external_sender) {
+                        warn!(error = ?e, "error setting MLS external sender");
+                    }
                 }
             },
             GatewayEvent::DaveMlsProposals(ev) => {
@@ -292,69 +313,65 @@ impl AuxNetwork {
                     DaveMlsProposalsOperationType::Append => davey::ProposalsOperationType::APPEND,
                     DaveMlsProposalsOperationType::Revoke => davey::ProposalsOperationType::REVOKE,
                 };
-                if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                    dave_session
-                        .process_proposals(operation_type, &ev.proposals, None)
-                        .expect("TODO");
+                let result = if let Some(ref mut dave_session) = *self.dave_session.write() {
+                    match dave_session.process_proposals(operation_type, &ev.proposals, None) {
+                        Ok(result) => result,
+                        Err(e) => {
+                            warn!(error = ?e, "error processing MLS proposals");
+                            None
+                        },
+                    }
+                } else {
+                    None
+                };
+
+                if let Some(commit_welcome) = result {
+                    self.ws_client
+                        .send_binary(&GatewayEvent::from(DaveMlsCommitWelcome {
+                            commit: commit_welcome.commit,
+                            welcome: commit_welcome.welcome,
+                        }))
+                        .await?;
                 }
             },
             GatewayEvent::DaveMlsAnnounceCommitTransition(ev) => {
-                let mut lock = self.dave_session.write().await;
+                match self.dave_process_commit(&ev.commit_message) {
+                    Some(Ok(_)) => {
+                        if ev.transition_id != 0 {
+                            let protocol_version =
+                                self.dave_protocol_version.load(Ordering::Relaxed);
 
-                if let Some(ref mut dave_session) = *lock {
-                    match dave_session.process_commit(&ev.commit_message) {
-                        Ok(_) => {
-                            if ev.transition_id != 0 {
-                                self.dave_pending_transitions.insert(
-                                    ev.transition_id,
-                                    dave_session.protocol_version().into(),
-                                );
-                                self.ws_client
-                                    .send_json(&GatewayEvent::DaveTransitionReady(
-                                        DaveTransitionReady {
-                                            transition_id: ev.transition_id,
-                                            protocol_version: dave_session
-                                                .protocol_version()
-                                                .into(),
-                                        },
-                                    ))
-                                    .await?;
-                            }
-                        },
-                        Err(e) => {
-                            warn!("MLS commit errored: {e:?}");
+                            self.dave_pending_transitions
+                                .insert(ev.transition_id, protocol_version);
                             self.ws_client
-                                .send_json(&GatewayEvent::DaveMlsInvalidCommitWelcome(
-                                    DaveMlsInvalidCommitWelcome {
-                                        transition_id: ev.transition_id,
-                                    },
-                                ))
+                                .send_json(&GatewayEvent::from(DaveTransitionReady {
+                                    transition_id: ev.transition_id,
+                                    protocol_version,
+                                }))
                                 .await?;
-                            drop(lock);
-                            self.reinit_dave_session().await;
-                        },
-                    }
-                }
+                        }
+                    },
+                    Some(Err(e)) => {
+                        warn!("MLS commit errored: {e:?}");
+                        self.ws_client
+                            .send_json(&GatewayEvent::from(DaveMlsInvalidCommitWelcome {
+                                transition_id: ev.transition_id,
+                            }))
+                            .await?;
+                        self.reinit_dave_session().await;
+                    },
+                    None => {},
+                };
             },
             GatewayEvent::DaveMlsWelcome(ev) => {
-                let mut lock = self.dave_session.write().await;
-
-                if let Some(ref mut dave_session) = *lock {
-                    match dave_session.process_welcome(&ev.welcome) {
-                        Ok(_) => {},
-                        Err(e) => {
-                            warn!("MLS welcome errored: {e:?}");
-                            self.ws_client
-                                .send_json(&GatewayEvent::DaveMlsInvalidCommitWelcome(
-                                    DaveMlsInvalidCommitWelcome {
-                                        transition_id: ev.transition_id,
-                                    },
-                                ))
-                                .await?;
-                            drop(lock);
-                            self.reinit_dave_session().await;
-                        },
-                    }
+                if let Some(Err(e)) = self.dave_process_welcome(&ev.welcome) {
+                    warn!("MLS welcome errored: {e:?}");
+                    self.ws_client
+                        .send_json(&GatewayEvent::from(DaveMlsInvalidCommitWelcome {
+                            transition_id: ev.transition_id,
+                        }))
+                        .await?;
+                    self.reinit_dave_session().await;
                 }
             },
             other => {
@@ -365,29 +382,49 @@ impl AuxNetwork {
         Ok(())
     }
 
-    async fn reinit_dave_session(&mut self) {
-        if let Some(dave_protocol_version) = self.dave_protocol_version {
-            let key_package = if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                dave_session
-                    .reinit(
-                        dave_protocol_version,
-                        self.info.user_id.0.into(),
-                        self.info.channel_id.expect("TODO").0.into(),
-                        None,
-                    )
-                    .expect("TODO");
-                dave_session.create_key_package().expect("TODO")
-            } else {
-                let mut dave_session = davey::DaveSession::new(
-                    dave_protocol_version,
-                    self.info.user_id.0.into(),
-                    self.info.channel_id.expect("TODO").0.into(),
-                    None,
-                )
-                .expect("TODO");
-                let key_package = dave_session.create_key_package().expect("TODO");
+    fn dave_process_commit(
+        &mut self,
+        commit_message: &[u8],
+    ) -> Option<Result<(), davey::errors::ProcessCommitError>> {
+        let Some(ref mut dave_session) = *self.dave_session.write() else {
+            return None;
+        };
 
-                *self.dave_session.write().await = Some(dave_session);
+        Some(dave_session.process_commit(commit_message))
+    }
+
+    fn dave_process_welcome(
+        &mut self,
+        welcome: &[u8],
+    ) -> Option<Result<(), davey::errors::ProcessWelcomeError>> {
+        let Some(ref mut dave_session) = *self.dave_session.write() else {
+            return None;
+        };
+
+        Some(dave_session.process_welcome(welcome))
+    }
+
+    async fn reinit_dave_session(&mut self) -> Result<(), DaveReinitError> {
+        let protocol_version = self.dave_protocol_version.load(Ordering::Relaxed);
+
+        if let Some(dave_protocol_version) = NonZeroU16::new(protocol_version) {
+            let user_id = self.info.user_id.0.into();
+            let channel_id = self
+                .info
+                .channel_id
+                .expect("channel ID must be set")
+                .0
+                .into();
+
+            let key_package = if let Some(ref mut dave_session) = *self.dave_session.write() {
+                dave_session.reinit(dave_protocol_version, user_id, channel_id, None)?;
+                dave_session.create_key_package()?
+            } else {
+                let mut dave_session =
+                    davey::DaveSession::new(dave_protocol_version, user_id, channel_id, None)?;
+                let key_package = dave_session.create_key_package()?;
+
+                *self.dave_session.write() = Some(dave_session);
 
                 key_package
             };
@@ -396,12 +433,13 @@ impl AuxNetwork {
                 .send_binary(&GatewayEvent::DaveMlsKeyPackage(DaveMlsKeyPackage {
                     key_package,
                 }))
-                .await
-                .expect("TODO");
-        } else if let Some(ref mut dave_session) = *self.dave_session.write().await {
-            dave_session.reset().expect("TODO");
+                .await?;
+        } else if let Some(ref mut dave_session) = *self.dave_session.write() {
+            dave_session.reset()?;
             dave_session.set_passthrough_mode(true, Some(10));
         }
+
+        Ok(())
     }
 
     async fn execute_dave_transition(&mut self, transition_id: u16) {
@@ -409,18 +447,17 @@ impl AuxNetwork {
             warn!("Received DaveExecuteTransition for unknown transition ID {transition_id}");
             return;
         };
-        let old_version = if let Some(ref dave_session) = *self.dave_session.read().await {
-            dave_session.protocol_version().into()
-        } else {
-            0u16
-        };
+        let old_version = self.dave_protocol_version.load(Ordering::Relaxed);
+
+        self.dave_protocol_version
+            .store(*new_version, Ordering::Relaxed);
 
         if old_version != *new_version && *new_version == 0 {
             self.dave_downgraded = true;
         } else if transition_id > 0 && self.dave_downgraded {
             self.dave_downgraded = false;
 
-            if let Some(ref mut dave_session) = *self.dave_session.write().await {
+            if let Some(ref mut dave_session) = *self.dave_session.write() {
                 dave_session.set_passthrough_mode(true, Some(10));
             }
         }

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -241,6 +241,7 @@ impl AuxNetwork {
                 #[cfg(feature = "receive")]
                 if let Some(user_id) = &ev.user_id {
                     self.ssrc_signalling.user_ssrc_map.insert(*user_id, ev.ssrc);
+                    self.ssrc_signalling.ssrc_user_map.insert(ev.ssrc, *user_id);
                 }
 
                 drop(interconnect.events.send(EventMessage::FireCoreEvent(
@@ -299,7 +300,9 @@ impl AuxNetwork {
             GatewayEvent::DavePrepareEpoch(ev) if ev.epoch == 1 => {
                 self.dave_protocol_version
                     .store(ev.protocol_version, Ordering::Relaxed);
-                self.reinit_dave_session().await;
+                if let Err(e) = self.reinit_dave_session().await {
+                    warn!(error = ?e, "failed to reinitialize DAVE session");
+                }
             },
             GatewayEvent::DaveMlsExternalSender(ev) => {
                 if let Some(ref mut dave_session) = *self.dave_session.write() {
@@ -358,7 +361,9 @@ impl AuxNetwork {
                                 transition_id: ev.transition_id,
                             }))
                             .await?;
-                        self.reinit_dave_session().await;
+                        if let Err(e) = self.reinit_dave_session().await {
+                            warn!(error = ?e, "failed to reinitialize DAVE session");
+                        }
                     },
                     None => {},
                 };
@@ -371,7 +376,9 @@ impl AuxNetwork {
                             transition_id: ev.transition_id,
                         }))
                         .await?;
-                    self.reinit_dave_session().await;
+                    if let Err(e) = self.reinit_dave_session().await {
+                        warn!(error = ?e, "failed to reinitialize DAVE session");
+                    }
                 }
             },
             other => {

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -4,7 +4,10 @@ use crate::{
     events::CoreContext,
     model::{
         payload::{Heartbeat, Speaking},
-        CloseCode as VoiceCloseCode, Event as GatewayEvent, FromPrimitive, SpeakingState,
+        CloseCode as VoiceCloseCode,
+        Event as GatewayEvent,
+        FromPrimitive,
+        SpeakingState,
     },
     ws::{Error as WsError, WsStream},
     ConnectionInfo,
@@ -14,8 +17,11 @@ use rand::{distr::Uniform, Rng};
 use serenity_voice_model::{
     id::UserId,
     payload::{
-        DaveMlsCommitWelcome, DaveMlsInvalidCommitWelcome, DaveMlsKeyPackage,
-        DaveMlsProposalsOperationType, DaveTransitionReady,
+        DaveMlsCommitWelcome,
+        DaveMlsInvalidCommitWelcome,
+        DaveMlsKeyPackage,
+        DaveMlsProposalsOperationType,
+        DaveTransitionReady,
     },
 };
 use std::{
@@ -371,7 +377,7 @@ impl AuxNetwork {
             },
             GatewayEvent::DaveMlsAnnounceCommitTransition(ev) => {
                 match self.dave_process_commit(&ev.commit_message).await {
-                    Some(Ok(_)) => {
+                    Some(Ok(_)) =>
                         if ev.transition_id != 0 {
                             let protocol_version =
                                 self.dave_protocol_version.load(Ordering::Relaxed);
@@ -384,8 +390,7 @@ impl AuxNetwork {
                                     protocol_version,
                                 }))
                                 .await?;
-                        }
-                    },
+                        },
                     Some(Err(e)) => {
                         warn!("MLS commit errored: {e:?}");
                         self.ws_client
@@ -404,9 +409,9 @@ impl AuxNetwork {
                     None => {},
                 };
             },
-            GatewayEvent::DaveMlsWelcome(ev) => {
+            GatewayEvent::DaveMlsWelcome(ev) =>
                 match self.dave_process_welcome(&ev.welcome).await {
-                    Some(Ok(_)) => {
+                    Some(Ok(_)) =>
                         if ev.transition_id != 0 {
                             let protocol_version =
                                 self.dave_protocol_version.load(Ordering::Relaxed);
@@ -419,8 +424,7 @@ impl AuxNetwork {
                                     protocol_version,
                                 }))
                                 .await?;
-                        }
-                    },
+                        },
                     Some(Err(e)) => {
                         warn!("MLS welcome errored: {e:?}");
                         self.ws_client
@@ -437,8 +441,7 @@ impl AuxNetwork {
                         }
                     },
                     None => {},
-                }
-            },
+                },
             other => {
                 trace!("Received other websocket data: {:?}", other);
             },
@@ -539,24 +542,22 @@ fn ws_error_is_not_final(err: &WsError) -> bool {
     match err {
         #[cfg(feature = "tungstenite")]
         WsError::WsClosed(Some(frame)) => match frame.code {
-            CloseCode::Library(l) => {
+            CloseCode::Library(l) =>
                 if let Some(code) = VoiceCloseCode::from_u16(l) {
                     code.should_resume()
                 } else {
                     true
-                }
-            },
+                },
             _ => true,
         },
         #[cfg(feature = "tws")]
         WsError::WsClosed(Some(code)) => match (*code).into() {
-            code @ 4000..=4999_u16 => {
+            code @ 4000..=4999_u16 =>
                 if let Some(code) = VoiceCloseCode::from_u16(code) {
                     code.should_resume()
                 } else {
                     true
-                }
-            },
+                },
             _ => true,
         },
         e => {

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -30,12 +30,12 @@ use std::{
     sync::{
         atomic::{AtomicU16, Ordering},
         Arc,
+        RwLock,
     },
     time::Duration,
 };
 use tokio::{
     select,
-    sync::RwLock,
     time::{sleep_until, Instant},
 };
 #[cfg(feature = "tungstenite")]
@@ -304,7 +304,7 @@ impl AuxNetwork {
                 if ev.transition_id == 0 {
                     self.execute_dave_transition(ev.transition_id).await;
                 } else if ev.protocol_version == 0 {
-                    if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                    if let Some(ref mut dave_session) = *self.dave_session.write().unwrap() {
                         dave_session.set_passthrough_mode(true, Some(120));
                     }
 
@@ -331,7 +331,7 @@ impl AuxNetwork {
                 }
             },
             GatewayEvent::DaveMlsExternalSender(ev) => {
-                if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                if let Some(ref mut dave_session) = *self.dave_session.write().unwrap() {
                     if let Err(e) = dave_session.set_external_sender(&ev.external_sender) {
                         warn!(error = ?e, "error setting MLS external sender");
                     }
@@ -342,7 +342,8 @@ impl AuxNetwork {
                     DaveMlsProposalsOperationType::Append => davey::ProposalsOperationType::APPEND,
                     DaveMlsProposalsOperationType::Revoke => davey::ProposalsOperationType::REVOKE,
                 };
-                let result = if let Some(ref mut dave_session) = *self.dave_session.write().await {
+                let result = if let Some(ref mut dave_session) = *self.dave_session.write().unwrap()
+                {
                     match dave_session.process_proposals(
                         operation_type,
                         &ev.proposals,
@@ -452,7 +453,7 @@ impl AuxNetwork {
         &mut self,
         commit_message: &[u8],
     ) -> Option<Result<(), davey::errors::ProcessCommitError>> {
-        let Some(ref mut dave_session) = *self.dave_session.write().await else {
+        let Some(ref mut dave_session) = *self.dave_session.write().unwrap() else {
             return None;
         };
 
@@ -463,7 +464,7 @@ impl AuxNetwork {
         &mut self,
         welcome: &[u8],
     ) -> Option<Result<(), davey::errors::ProcessWelcomeError>> {
-        let Some(ref mut dave_session) = *self.dave_session.write().await else {
+        let Some(ref mut dave_session) = *self.dave_session.write().unwrap() else {
             return None;
         };
 
@@ -482,25 +483,26 @@ impl AuxNetwork {
                 .0
                 .into();
 
-            let key_package = if let Some(ref mut dave_session) = *self.dave_session.write().await {
-                dave_session.reinit(dave_protocol_version, user_id, channel_id, None)?;
-                dave_session.create_key_package()?
-            } else {
-                let mut dave_session =
-                    davey::DaveSession::new(dave_protocol_version, user_id, channel_id, None)?;
-                let key_package = dave_session.create_key_package()?;
+            let key_package =
+                if let Some(ref mut dave_session) = *self.dave_session.write().unwrap() {
+                    dave_session.reinit(dave_protocol_version, user_id, channel_id, None)?;
+                    dave_session.create_key_package()?
+                } else {
+                    let mut dave_session =
+                        davey::DaveSession::new(dave_protocol_version, user_id, channel_id, None)?;
+                    let key_package = dave_session.create_key_package()?;
 
-                *self.dave_session.write().await = Some(dave_session);
+                    *self.dave_session.write().unwrap() = Some(dave_session);
 
-                key_package
-            };
+                    key_package
+                };
 
             self.ws_client
                 .send_binary(&GatewayEvent::DaveMlsKeyPackage(DaveMlsKeyPackage {
                     key_package,
                 }))
                 .await?;
-        } else if let Some(ref mut dave_session) = *self.dave_session.write().await {
+        } else if let Some(ref mut dave_session) = *self.dave_session.write().unwrap() {
             dave_session.reset()?;
             dave_session.set_passthrough_mode(true, Some(10));
         }
@@ -520,7 +522,7 @@ impl AuxNetwork {
 
         // Upgraded from transport-only encryption
         if transition_id > 0 && old_version == 0 && new_version != 0 {
-            if let Some(ref mut dave_session) = *self.dave_session.write().await {
+            if let Some(ref mut dave_session) = *self.dave_session.write().unwrap() {
                 dave_session.set_passthrough_mode(true, Some(10));
             }
         }

--- a/src/driver/test_impls.rs
+++ b/src/driver/test_impls.rs
@@ -16,7 +16,13 @@ use crate::{
     tracks::LoopState,
 };
 use flume::Receiver;
-use std::{io::Cursor, net::UdpSocket, sync::Arc};
+use parking_lot::RwLock as PRwLock;
+use std::{
+    io::Cursor,
+    net::UdpSocket,
+    num::NonZeroU16,
+    sync::{atomic::AtomicU16, Arc},
+};
 use tokio::runtime::Handle;
 
 // create a dummied task + interconnect.
@@ -65,11 +71,23 @@ impl Mixer {
         let mode = CryptoMode::Aes256Gcm;
         let cipher = mode.cipher_from_key(&[0u8; 32]).unwrap();
         let crypto_state = mode.into();
+        let dave_protocol_version = Arc::new(AtomicU16::new(davey::DAVE_PROTOCOL_VERSION));
+        let dave_session = Arc::new(PRwLock::new(Some(
+            davey::DaveSession::new(
+                NonZeroU16::new(1).expect("failed to initialize NonZeroU16 from static value"),
+                1,
+                1,
+                None,
+            )
+            .expect("failed to initialize davey::DaveSession"),
+        )));
 
         #[cfg(feature = "receive")]
         let fake_conn = MixerConnection {
             cipher,
             crypto_state,
+            dave_session,
+            dave_protocol_version,
             udp_rx: udp_receiver_tx,
             udp_tx,
         };
@@ -78,6 +96,8 @@ impl Mixer {
         let fake_conn = MixerConnection {
             cipher,
             crypto_state,
+            dave_session,
+            dave_protocol_version,
             udp_tx,
         };
 

--- a/src/driver/test_impls.rs
+++ b/src/driver/test_impls.rs
@@ -20,9 +20,9 @@ use std::{
     io::Cursor,
     net::UdpSocket,
     num::NonZeroU16,
-    sync::{atomic::AtomicU16, Arc},
+    sync::{atomic::AtomicU16, Arc, RwLock},
 };
-use tokio::{runtime::Handle, sync::RwLock};
+use tokio::runtime::Handle;
 
 // create a dummied task + interconnect.
 // measure perf at varying numbers of sources (binary 1--64) without passthrough support.

--- a/src/driver/test_impls.rs
+++ b/src/driver/test_impls.rs
@@ -16,14 +16,13 @@ use crate::{
     tracks::LoopState,
 };
 use flume::Receiver;
-use parking_lot::RwLock as PRwLock;
 use std::{
     io::Cursor,
     net::UdpSocket,
     num::NonZeroU16,
     sync::{atomic::AtomicU16, Arc},
 };
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, sync::RwLock};
 
 // create a dummied task + interconnect.
 // measure perf at varying numbers of sources (binary 1--64) without passthrough support.
@@ -72,7 +71,7 @@ impl Mixer {
         let cipher = mode.cipher_from_key(&[0u8; 32]).unwrap();
         let crypto_state = mode.into();
         let dave_protocol_version = Arc::new(AtomicU16::new(davey::DAVE_PROTOCOL_VERSION));
-        let dave_session = Arc::new(PRwLock::new(Some(
+        let dave_session = Arc::new(RwLock::new(Some(
             davey::DaveSession::new(
                 NonZeroU16::new(1).expect("failed to initialize NonZeroU16 from static value"),
                 1,

--- a/src/events/context/data/disconnect.rs
+++ b/src/events/context/data/disconnect.rs
@@ -94,6 +94,8 @@ impl From<&ConnectionError> for DisconnectReason {
             ConnectionError::CryptoInvalidLength
             | ConnectionError::CryptoModeInvalid
             | ConnectionError::CryptoModeUnavailable
+            | ConnectionError::DaveCreateKeyPackageError(_)
+            | ConnectionError::DaveInitializationError(_)
             | ConnectionError::EndpointUrl
             | ConnectionError::IllegalDiscoveryResponse
             | ConnectionError::IllegalIp

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -1,5 +1,11 @@
 use crate::input::{
-    metadata::ytdl::Output, AudioStream, AudioStreamError, AuxMetadata, Compose, HttpRequest, Input,
+    metadata::ytdl::Output,
+    AudioStream,
+    AudioStreamError,
+    AuxMetadata,
+    Compose,
+    HttpRequest,
+    Input,
 };
 use async_trait::async_trait;
 use either::Either;

--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -1,11 +1,5 @@
 use crate::input::{
-    metadata::ytdl::Output,
-    AudioStream,
-    AudioStreamError,
-    AuxMetadata,
-    Compose,
-    HttpRequest,
-    Input,
+    metadata::ytdl::Output, AudioStream, AudioStreamError, AuxMetadata, Compose, HttpRequest, Input,
 };
 use async_trait::async_trait;
 use either::Either;
@@ -167,7 +161,7 @@ impl<'a> YoutubeDl<'a> {
         let out = output
             .stdout
             .split(|&b| b == b'\n')
-            .filter(|&x| (!x.is_empty()))
+            .filter(|&x| !x.is_empty())
             .map(serde_json::from_slice)
             .collect::<Result<Vec<Output>, _>>()
             .map_err(|e| AudioStreamError::Fail(Box::new(e)))?;

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -145,12 +145,16 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
                 .ok())
         },
         Some(Message::Binary(bytes)) => {
-            return Ok(deserialize_binary_event(bytes.iter().as_slice())
-                .map_err(|e| {
-                    debug!("Unexpected binary: {e}");
-                    e
-                })
-                .ok());
+            return Ok(
+                // HACK: empty bytes as placeholder for the sequence number, remove
+                // when upgrading to voice v8
+                deserialize_binary_event(&[&[0u8, 0u8] as &[_], &bytes].concat())
+                    .map_err(|e| {
+                        debug!("Unexpected binary: {e}");
+                        e
+                    })
+                    .ok(),
+            );
         },
         Some(Message::Close(Some(frame))) => {
             return Err(Error::WsClosed(Some(frame)));

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -178,12 +178,14 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
             };
         },
         Some(message) if message.is_binary() => {
-            return Ok(deserialize_binary_event(&message.into_payload())
-                .map_err(|e| {
-                    debug!("Unexpected binary: {e}");
-                    e
-                })
-                .ok());
+            return Ok(deserialize_binary_event(
+                &[&[0u8, 0u8] as &[_], &message.into_payload()].concat(),
+            )
+            .map_err(|e| {
+                debug!("Unexpected binary: {e}");
+                e
+            })
+            .ok());
         },
         Some(message) if message.is_close() => {
             return Err(Error::WsClosed(message.as_close().map(|(c, _)| c)));

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -17,11 +17,17 @@ use tokio_tungstenite::{
         protocol::{CloseFrame, WebSocketConfig as Config},
         Message,
     },
-    MaybeTlsStream, WebSocketStream,
+    MaybeTlsStream,
+    WebSocketStream,
 };
 #[cfg(feature = "tws")]
 use tokio_websockets::{
-    CloseCode, Error as TwsError, Limits, MaybeTlsStream, Message, WebSocketStream,
+    CloseCode,
+    Error as TwsError,
+    Limits,
+    MaybeTlsStream,
+    Message,
+    WebSocketStream,
 };
 use tracing::{debug, instrument};
 use url::Url;
@@ -136,14 +142,13 @@ impl From<BinaryError> for Error {
 pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Event>> {
     #[cfg(feature = "tungstenite")]
     match message {
-        Some(Message::Text(ref payload)) => {
+        Some(Message::Text(ref payload)) =>
             return Ok(serde_json::from_str(payload)
                 .map_err(|e| {
                     debug!("Unexpected JSON: {e}. Payload: {payload}");
                     e
                 })
-                .ok())
-        },
+                .ok()),
         Some(Message::Binary(bytes)) => {
             return Ok(deserialize_binary_event(&bytes)
                 .map_err(|e| {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -145,16 +145,12 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
                 .ok())
         },
         Some(Message::Binary(bytes)) => {
-            return Ok(
-                // HACK: empty bytes as placeholder for the sequence number, remove
-                // when upgrading to voice v8
-                deserialize_binary_event(&[&[0u8, 0u8] as &[_], &bytes].concat())
-                    .map_err(|e| {
-                        debug!("Unexpected binary: {e}");
-                        e
-                    })
-                    .ok(),
-            );
+            return Ok(deserialize_binary_event(&bytes)
+                .map_err(|e| {
+                    debug!("Unexpected binary: {e}");
+                    e
+                })
+                .ok());
         },
         Some(Message::Close(Some(frame))) => {
             return Err(Error::WsClosed(Some(frame)));
@@ -178,14 +174,12 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
             };
         },
         Some(message) if message.is_binary() => {
-            return Ok(deserialize_binary_event(
-                &[&[0u8, 0u8] as &[_], &message.into_payload()].concat(),
-            )
-            .map_err(|e| {
-                debug!("Unexpected binary: {e}");
-                e
-            })
-            .ok());
+            return Ok(deserialize_binary_event(&message.into_payload())
+                .map_err(|e| {
+                    debug!("Unexpected binary: {e}");
+                    e
+                })
+                .ok());
         },
         Some(message) if message.is_close() => {
             return Err(Error::WsClosed(message.as_close().map(|(c, _)| c)));

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,7 +1,11 @@
-use crate::{error::JsonError, model::Event};
+use crate::{
+    error::JsonError,
+    model::{deserialize_binary_event, Event},
+};
 
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt, TryStreamExt};
+use serenity_voice_model::{serialize_binary_event, BinaryError};
 use tokio::{
     net::TcpStream,
     time::{timeout, Duration},
@@ -13,17 +17,11 @@ use tokio_tungstenite::{
         protocol::{CloseFrame, WebSocketConfig as Config},
         Message,
     },
-    MaybeTlsStream,
-    WebSocketStream,
+    MaybeTlsStream, WebSocketStream,
 };
 #[cfg(feature = "tws")]
 use tokio_websockets::{
-    CloseCode,
-    Error as TwsError,
-    Limits,
-    MaybeTlsStream,
-    Message,
-    WebSocketStream,
+    CloseCode, Error as TwsError, Limits, MaybeTlsStream, Message, WebSocketStream,
 };
 use tracing::{debug, instrument};
 use url::Url;
@@ -55,7 +53,7 @@ impl WsStream {
         Ok(Self(stream))
     }
 
-    pub(crate) async fn recv_json(&mut self) -> Result<Option<Event>> {
+    pub(crate) async fn recv_event(&mut self) -> Result<Option<Event>> {
         const TIMEOUT: Duration = Duration::from_millis(500);
 
         let ws_message = match timeout(TIMEOUT, self.0.next()).await {
@@ -67,13 +65,20 @@ impl WsStream {
         convert_ws_message(ws_message)
     }
 
-    pub(crate) async fn recv_json_no_timeout(&mut self) -> Result<Option<Event>> {
+    pub(crate) async fn recv_event_no_timeout(&mut self) -> Result<Option<Event>> {
         convert_ws_message(self.0.try_next().await?)
     }
 
     pub(crate) async fn send_json(&mut self, value: &Event) -> Result<()> {
         let res = crate::json::to_string(value);
         let res = res.map(Message::text);
+        Ok(res.map_err(Error::from).map(|m| self.0.send(m))?.await?)
+    }
+
+    pub(crate) async fn send_binary(&mut self, value: &Event) -> Result<()> {
+        let res = serialize_binary_event(value);
+        let res = res.map(Message::binary);
+
         Ok(res.map_err(Error::from).map(|m| self.0.send(m))?.await?)
     }
 }
@@ -97,6 +102,8 @@ pub enum Error {
     WsClosed(Option<CloseFrame>),
     #[cfg(feature = "tws")]
     WsClosed(Option<CloseCode>),
+
+    Binary(BinaryError),
 }
 
 impl From<JsonError> for Error {
@@ -119,13 +126,31 @@ impl From<TwsError> for Error {
     }
 }
 
+impl From<BinaryError> for Error {
+    fn from(value: BinaryError) -> Self {
+        Error::Binary(value)
+    }
+}
+
 #[inline]
 pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Event>> {
     #[cfg(feature = "tungstenite")]
-    let text = match message {
-        Some(Message::Text(ref payload)) => payload,
+    match message {
+        Some(Message::Text(ref payload)) => {
+            return Ok(serde_json::from_str(payload)
+                .map_err(|e| {
+                    debug!("Unexpected JSON: {e}. Payload: {payload}");
+                    e
+                })
+                .ok())
+        },
         Some(Message::Binary(bytes)) => {
-            return Err(Error::UnexpectedBinaryMessage(bytes));
+            return Ok(deserialize_binary_event(bytes.iter().as_slice())
+                .map_err(|e| {
+                    debug!("Unexpected binary: {e}");
+                    e
+                })
+                .ok());
         },
         Some(Message::Close(Some(frame))) => {
             return Err(Error::WsClosed(Some(frame)));
@@ -133,18 +158,28 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
         // Ping/Pong message behaviour is internally handled by tungstenite.
         _ => return Ok(None),
     };
+
     #[cfg(feature = "tws")]
-    let text = match message {
-        Some(ref message) if message.is_text() =>
-            if let Some(text) = message.as_text() {
-                text
+    match message {
+        Some(ref message) if message.is_text() => {
+            return if let Some(text) = message.as_text() {
+                Ok(serde_json::from_str(text)
+                    .map_err(|e| {
+                        debug!("Unexpected JSON: {e}. Payload: {text}");
+                        e
+                    })
+                    .ok())
             } else {
-                return Ok(None);
-            },
+                Ok(None)
+            };
+        },
         Some(message) if message.is_binary() => {
-            return Err(Error::UnexpectedBinaryMessage(
-                message.into_payload().into(),
-            ));
+            return Ok(deserialize_binary_event(&message.into_payload())
+                .map_err(|e| {
+                    debug!("Unexpected binary: {e}");
+                    e
+                })
+                .ok());
         },
         Some(message) if message.is_close() => {
             return Err(Error::WsClosed(message.as_close().map(|(c, _)| c)));
@@ -152,11 +187,4 @@ pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Even
         // ping/pong; will also be internally handled by tokio-websockets.
         _ => return Ok(None),
     };
-
-    Ok(serde_json::from_str(text)
-        .map_err(|e| {
-            debug!("Unexpected JSON: {e}. Payload: {text}");
-            e
-        })
-        .ok())
 }


### PR DESCRIPTION
Closes #293

Sending voice packets now mostly works.

Receiving is not very heavily tested, and there are a bunch of annoyances:
- ~~Passthrough (unencrypted) voice packets will still go into the decryption code path, so you will get error logs like:~~
```
ERROR davey::cryptor::frame_processors: no magic marker
```
- ~~The UDP receiving task is separate from the gateway task, so decrypting the first few packets *will* fail because the key ratchets haven't been set up yet. This should probably be fixed with a buffer?~~ Packets that are received before the key ratchets are set up are silently dropped.
- `SpeakingStateUpdate` events are apparently not fired consistently

~~The PR is still unreviewed, but~~ if your bot needs this it's been tested and working on a few bots. If you use `serenity-next`, you may want to depend on jtscuba's fork of this PR instead, which depends on `serenity-next`: https://github.com/jtscuba/songbird/tree/davey

## TODO
- [x] `serenity-voice-model` will need to be updated on crates.io to add the missing `dave_protocol_version` field in `SessionDescription`.
- [ ] Add a way to retrieve the voice privacy code and the verification codes (e.g. `Call::voice_privacy_code`?)