### PR TITLE
Switch from audiopus to opus2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.5.0"
 aead = { optional = true, version = "0.5.2" }
 aes-gcm = { optional = true, version = "0.10.3" }
 async-trait = { optional = true, version = "0.1" }
-audiopus = { optional = true, version = "0.3.0-rc.0" }
+opus2 = { optional = true, version = "0.4.0" }
 byteorder = { optional = true, version = "1" }
 bytes = { optional = true, version = "1" }
 chacha20poly1305 = { optional = true, version = "0.10.1" }
@@ -96,7 +96,7 @@ driver = [
     "dep:aead",
     "dep:aes-gcm",
     "dep:async-trait",
-    "dep:audiopus",
+    "dep:opus2",
     "dep:byteorder",
     "dep:bytes",
     "dep:chacha20poly1305",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Songbird's gateway functionality requires you to specify the `GUILD_VOICE_STATES
 
 ## Codec support
 Songbird supports all [codecs and formats provided by Symphonia] (pure-Rust), with Opus support
-provided by [audiopus] (an FFI wrapper for libopus).
+provided by [opus2] (an FFI wrapper for libopus).
 
 **By default, *Songbird will not request any codecs from Symphonia*.** To change this, in your own
 project you will need to depend on Symphonia as well.
@@ -44,7 +44,7 @@ features = ["aac", "mp3", "isomp4", "alac"] # ...as well as any extras you need!
 Songbird needs a few system dependencies before you can use it.
 
 - Opus - Audio codec that Discord uses.
-[audiopus] will use installed libopus binaries if available via pkgconf on Linux/MacOS, otherwise you will need to install cmake to build opus from source.
+[opus2] will use installed libopus binaries if available via pkgconf on Linux/MacOS, otherwise you will need to install cmake to build opus from source.
 This is always the case on Windows.
 For Unix systems, you can install the library with `apt install libopus-dev` on Ubuntu or `pacman -S opus` on Arch Linux.
 If you do not have it installed it will be built for you. However, you will need a C compiler and the GNU autotools installed.
@@ -75,7 +75,7 @@ Songbird's logo is based upon the copyright-free image ["Black-Capped Chickadee"
 [this crate's examples directory]: https://github.com/serenity-rs/songbird/tree/current/examples
 [our contributor guidelines]: CONTRIBUTING.md
 [codecs and formats provided by Symphonia]: https://github.com/pdeljanov/Symphonia#formats-demuxers
-[audiopus]: https://github.com/lakelezz/audiopus
+[opus2]: https://github.com/cijiugechu/opus2
 [according to the installation instructions on the main repo]: https://github.com/yt-dlp/yt-dlp#installation
 
 [build badge]: https://img.shields.io/github/actions/workflow/status/serenity-rs/songbird/ci.yml?branch=current&style=flat-square

--- a/examples/serenity/voice_cached_audio/src/main.rs
+++ b/examples/serenity/voice_cached_audio/src/main.rs
@@ -143,7 +143,7 @@ async fn main() {
         // Music by Cloudkicker, used under CC BY-SC-SA 3.0 (https://creativecommons.org/licenses/by-nc-sa/3.0/).
         let song_src = Compressed::new(
             File::new("../../../resources/Cloudkicker - 2011 07.mp3").into(),
-            Bitrate::BitsPerSecond(128_000),
+            Bitrate::Bits(128_000),
         )
         .await
         .expect("These parameters are well-defined.");

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,7 +158,7 @@ pub struct Config {
 
     #[cfg(feature = "driver")]
     #[derivative(Debug = "ignore")]
-    /// Registry of the inner codecs supported by the driver, adding audiopus-based
+    /// Registry of the inner codecs supported by the driver, adding opus2-based
     /// Opus codec support to all of Symphonia's default codecs.
     ///
     /// Defaults to [`get_codec_registry`].

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,9 +1,9 @@
 //! Constants affecting driver function and API handling.
 
 #[cfg(feature = "driver")]
-use audiopus::{Bitrate, SampleRate};
-#[cfg(feature = "driver")]
 use discortp::rtp::RtpType;
+#[cfg(feature = "driver")]
+use opus2::Bitrate;
 use std::time::Duration;
 
 #[cfg(feature = "driver")]
@@ -12,7 +12,7 @@ pub const VOICE_GATEWAY_VERSION: u8 = crate::model::constants::GATEWAY_VERSION;
 
 #[cfg(feature = "driver")]
 /// Sample rate of audio to be sent to Discord.
-pub const SAMPLE_RATE: SampleRate = SampleRate::Hz48000;
+pub const SAMPLE_RATE: u32 = 48000;
 
 /// Sample rate of audio to be sent to Discord.
 pub const SAMPLE_RATE_RAW: usize = 48_000;
@@ -25,7 +25,7 @@ pub const TIMESTEP_LENGTH: Duration = Duration::from_millis(1000 / AUDIO_FRAME_R
 
 #[cfg(feature = "driver")]
 /// Default bitrate for audio.
-pub const DEFAULT_BITRATE: Bitrate = Bitrate::BitsPerSecond(128_000);
+pub const DEFAULT_BITRATE: Bitrate = Bitrate::Bits(128_000);
 
 /// Number of output samples at 48kHZ to produced when resampling subframes.
 pub(crate) const RESAMPLE_OUTPUT_FRAME_SIZE: usize = MONO_FRAME_SIZE / 2;

--- a/src/driver/decode_mode.rs
+++ b/src/driver/decode_mode.rs
@@ -1,4 +1,4 @@
-use audiopus::{Channels as OpusChannels, SampleRate as OpusRate};
+use opus2::Channels as OpusChannels;
 
 /// Decode behaviour for received RTP packets within the driver.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -112,14 +112,14 @@ pub enum SampleRate {
     Hz48000,
 }
 
-impl From<SampleRate> for OpusRate {
+impl From<SampleRate> for u32 {
     fn from(value: SampleRate) -> Self {
         match value {
-            SampleRate::Hz8000 => OpusRate::Hz8000,
-            SampleRate::Hz12000 => OpusRate::Hz12000,
-            SampleRate::Hz16000 => OpusRate::Hz16000,
-            SampleRate::Hz24000 => OpusRate::Hz24000,
-            SampleRate::Hz48000 => OpusRate::Hz48000,
+            SampleRate::Hz8000 => 8000,
+            SampleRate::Hz12000 => 12000,
+            SampleRate::Hz16000 => 16000,
+            SampleRate::Hz24000 => 24000,
+            SampleRate::Hz48000 => 48000,
         }
     }
 }

--- a/src/driver/mix_mode.rs
+++ b/src/driver/mix_mode.rs
@@ -1,4 +1,4 @@
-use audiopus::Channels;
+use opus2::Channels;
 use symphonia_core::audio::Layout;
 
 use crate::constants::{MONO_FRAME_SIZE, STEREO_FRAME_SIZE};

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -54,14 +54,14 @@ use crate::{
     Event,
     EventHandler,
 };
-/// Opus encoder bitrate settings.
-pub use audiopus::{self as opus, Bitrate};
 use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 use flume::{r#async::RecvFut, SendError, Sender};
+/// Opus encoder bitrate settings.
+pub use opus2::{self as opus, Bitrate};
 #[cfg(feature = "builtin-queue")]
 use std::time::Duration;
 #[allow(unused_imports)]

--- a/src/driver/tasks/error.rs
+++ b/src/driver/tasks/error.rs
@@ -1,9 +1,9 @@
 use super::message::*;
 use crate::ws::Error as WsError;
 use aes_gcm::Error as CryptoError;
-use audiopus::Error as OpusError;
 use davey::errors::EncryptError as DaveyEncryptError;
 use flume::SendError;
+use opus2::Error as OpusError;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
 #[derive(Debug)]

--- a/src/driver/tasks/mixer/mix_logic.rs
+++ b/src/driver/tasks/mixer/mix_logic.rs
@@ -69,9 +69,7 @@ pub fn mix_symph_indiv(
             // Opus packet passthrough special case.
             if codec_type == CODEC_TYPE_OPUS && local_state.passthrough != Passthrough::Block {
                 if let Some(slot) = opus_slot.as_mut() {
-                    let sample_ct = buf
-                        .try_into()
-                        .and_then(|buf| audiopus::packet::nb_samples(buf, SAMPLE_RATE));
+                    let sample_ct = opus2::packet::get_nb_samples(buf, SAMPLE_RATE);
 
                     // We don't actually block passthrough until a few violations are
                     // seen. The main one is that most Opus tracks end on a sub-20ms

--- a/src/driver/tasks/mixer/mix_logic.rs
+++ b/src/driver/tasks/mixer/mix_logic.rs
@@ -69,7 +69,11 @@ pub fn mix_symph_indiv(
             // Opus packet passthrough special case.
             if codec_type == CODEC_TYPE_OPUS && local_state.passthrough != Passthrough::Block {
                 if let Some(slot) = opus_slot.as_mut() {
-                    let sample_ct = opus2::packet::get_nb_samples(buf, SAMPLE_RATE);
+                    let sample_ct = if buf.is_empty() || buf.len() > i32::MAX as usize {
+                        None
+                    } else {
+                        Some(opus2::packet::get_nb_samples(buf, SAMPLE_RATE))
+                    };
 
                     // We don't actually block passthrough until a few violations are
                     // seen. The main one is that most Opus tracks end on a sub-20ms
@@ -78,7 +82,7 @@ pub fn mix_symph_indiv(
                     let buf_size_fatal = buf.len() >= slot.len();
 
                     if match sample_ct {
-                        Ok(MONO_FRAME_SIZE) => true,
+                        Some(Ok(MONO_FRAME_SIZE)) => true,
                         _ => !local_state.record_and_check_passthrough_strike_final(buf_size_fatal),
                     } {
                         slot.write_all(buf)

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -23,18 +23,13 @@ use crate::{
     tracks::{Action, LoopState, PlayError, PlayMode, TrackCommand, TrackHandle, TrackState, View},
     Config,
 };
-use audiopus::{
-    coder::Encoder as OpusEncoder,
-    softclip::SoftClip,
-    Application as CodingMode,
-    Bitrate,
-};
 use discortp::{
     discord::MutableKeepalivePacket,
     rtp::{MutableRtpPacket, RtpPacket},
     MutablePacket,
 };
 use flume::{Receiver, SendError, Sender, TryRecvError};
+use opus2::{Application as CodingMode, Bitrate, Encoder as OpusEncoder, SoftClip};
 use rand::random;
 use rubato::{FftFixedOut, Resampler};
 use std::{
@@ -574,7 +569,7 @@ impl Mixer {
                             [..n * self.config.mix_mode.channels()])
                             .try_into()
                             .expect("Mix buffer is known to have a valid sample count (softclip)."),
-                    )?;
+                    );
                 }
             }
         }

--- a/src/driver/tasks/mixer/mod.rs
+++ b/src/driver/tasks/mixer/mod.rs
@@ -565,10 +565,8 @@ impl Mixer {
             if let MixType::MixedPcm(n) = mix_len {
                 if self.config.use_softclip {
                     self.soft_clip.apply(
-                        (&mut self.sample_buffer.samples_mut()
-                            [..n * self.config.mix_mode.channels()])
-                            .try_into()
-                            .expect("Mix buffer is known to have a valid sample count (softclip)."),
+                        &mut self.sample_buffer.samples_mut()
+                            [..n * self.config.mix_mode.channels()],
                     );
                 }
             }

--- a/src/driver/tasks/udp_rx/ssrc_state.rs
+++ b/src/driver/tasks/udp_rx/ssrc_state.rs
@@ -8,12 +8,8 @@ use crate::{
     },
     events::context_data::{RtpData, VoiceData},
 };
-use audiopus::{
-    coder::Decoder as OpusDecoder,
-    error::{Error as OpusError, ErrorCode},
-    packet::Packet as OpusPacket,
-};
 use discortp::{rtp::RtpExtensionPacket, Packet, PacketSize};
+use opus2::{Decoder as OpusDecoder, ErrorCode};
 use tracing::{error, warn};
 
 #[derive(Debug)]
@@ -116,7 +112,7 @@ impl SsrcState {
             let dest_samples = (&mut audio[..])
                 .try_into()
                 .expect("Decode logic will cap decode buffer size at i32::MAX.");
-            let len = self.decoder.decode(None, dest_samples, false)?;
+            let len = self.decoder.decode(&[], dest_samples, false)?;
             audio.truncate(2 * len);
 
             out.decoded_voice = Some(audio);
@@ -147,11 +143,10 @@ impl SsrcState {
             let mut out = vec![0; self.decode_size.len()];
 
             for _ in 0..missed_packets {
-                let missing_frame: Option<OpusPacket<'_>> = None;
                 let dest_samples = (&mut out[..])
                     .try_into()
                     .expect("Decode logic will cap decode buffer size at i32::MAX.");
-                if let Err(e) = self.decoder.decode(missing_frame, dest_samples, false) {
+                if let Err(e) = self.decoder.decode(&[], dest_samples, false) {
                     warn!("Issue while decoding for missed packet: {:?}.", e);
                 }
             }
@@ -163,11 +158,7 @@ impl SsrcState {
             // This should scan up to find the "correct" size that a source is using,
             // and then remember that.
             loop {
-                let tried_audio_len = self.decoder.decode(
-                    Some(data[start..].try_into()?),
-                    (&mut out[..]).try_into()?,
-                    false,
-                );
+                let tried_audio_len = self.decoder.decode(&data[start..], &mut out, false);
                 match tried_audio_len {
                     Ok(audio_len) => {
                         // Decoding to stereo: audio_len refers to sample count irrespective of channel count.
@@ -176,7 +167,7 @@ impl SsrcState {
 
                         break;
                     },
-                    Err(OpusError::Opus(ErrorCode::BufferTooSmall)) => {
+                    Err(e) if e.code() == ErrorCode::BufferTooSmall => {
                         if self.decode_size.can_bump_up() {
                             self.decode_size = self.decode_size.bump_up();
                             out = vec![0; self.decode_size.len()];

--- a/src/driver/test_impls.rs
+++ b/src/driver/test_impls.rs
@@ -177,7 +177,7 @@ impl Mixer {
         let input: Input = RawAdapter::new(Cursor::new(floats), 48_000, 2).into();
 
         let mut src = handle.block_on(async move {
-            Compressed::new(input, Bitrate::BitsPerSecond(128_000))
+            Compressed::new(input, Bitrate::Bits(128_000))
                 .await
                 .expect("These parameters are well-defined.")
         });

--- a/src/input/adapters/cached/compressed.rs
+++ b/src/input/adapters/cached/compressed.rs
@@ -8,16 +8,8 @@ use crate::{
         LiveInput,
     },
 };
-use audiopus::{
-    coder::{Encoder as OpusEncoder, GenericCtl},
-    Application,
-    Bitrate,
-    Channels,
-    Error as OpusError,
-    ErrorCode as OpusErrorCode,
-    SampleRate,
-};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use opus2::{Application, Bitrate, Channels, Encoder as OpusEncoder, ErrorCode as OpusErrorCode};
 use std::{
     io::{
         Cursor,
@@ -52,7 +44,7 @@ use tracing::{debug, trace};
 pub struct Config {
     /// Registry of audio codecs supported by the driver.
     ///
-    /// Defaults to [`get_codec_registry`], which adds audiopus-based Opus codec support
+    /// Defaults to [`get_codec_registry`], which adds opus2-based Opus codec support
     /// to all of Symphonia's default codecs.
     pub codec_registry: &'static CodecRegistry,
     /// Registry of the muxers and container formats supported by the driver.
@@ -175,7 +167,7 @@ impl Compressed {
             (Channels::Mono, false)
         };
 
-        let mut encoder = OpusEncoder::new(SampleRate::Hz48000, channels, Application::Audio)?;
+        let mut encoder = OpusEncoder::new(48000, channels, Application::Audio)?;
         encoder.set_bitrate(bitrate)?;
 
         let codec_type = parsed.decoder.codec_params().codec;
@@ -190,7 +182,7 @@ impl Compressed {
         let metadata = create_metadata(
             &mut parsed.meta,
             format_meta,
-            &encoder,
+            &mut encoder,
             chan_count as u8,
             encoding,
         )?;
@@ -227,7 +219,7 @@ impl Compressed {
 fn create_metadata(
     probe_metadata: &mut ProbedMetadata,
     track_metadata: Option<&MetadataRevision>,
-    opus: &OpusEncoder,
+    opus: &mut OpusEncoder,
     channels: u8,
     encoding: Option<String>,
 ) -> Result<DcaMetadata, CodecCacheError> {
@@ -241,27 +233,27 @@ fn create_metadata(
         },
     };
 
-    let abr = match opus.bitrate()? {
-        Bitrate::BitsPerSecond(i) => Some(i as u64),
+    let abr = match opus.get_bitrate()? {
+        Bitrate::Bits(i) => Some(i as u64),
         Bitrate::Auto => None,
         Bitrate::Max => Some(510_000),
     };
 
-    let mode = match opus.application()? {
+    let mode = match opus.get_application()? {
         Application::Voip => "voip",
         Application::Audio => "music",
         Application::LowDelay => "lowdelay",
     }
     .to_string();
 
-    let sample_rate = opus.sample_rate()? as u32;
+    let sample_rate = opus.get_sample_rate()?;
 
     let opus = Opus {
         mode,
         sample_rate,
         frame_size: MONO_FRAME_BYTE_SIZE as u64,
         abr,
-        vbr: opus.vbr()?,
+        vbr: opus.get_vbr()?,
         channels: channels.min(2),
     };
 
@@ -427,7 +419,7 @@ where
                             self.last_frame.truncate(pkt_len);
                             break;
                         },
-                        Err(OpusError::Opus(OpusErrorCode::BufferTooSmall)) => {
+                        Err(e) if e.code() == OpusErrorCode::BufferTooSmall => {
                             // If we need more capacity to encode this frame, then take it.
                             trace!("Resizing inner buffer (+256).");
                             self.last_frame.resize(self.last_frame.len() + 256, 0);

--- a/src/input/adapters/cached/error.rs
+++ b/src/input/adapters/cached/error.rs
@@ -1,5 +1,5 @@
 use crate::{error::JsonError, input::AudioStreamError};
-use audiopus::error::Error as OpusError;
+use opus2::Error as OpusError;
 use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/src/input/adapters/cached/mod.rs
+++ b/src/input/adapters/cached/mod.rs
@@ -13,7 +13,7 @@ pub use self::{compressed::*, decompressed::*, error::*, hint::*, memory::*};
 
 use crate::constants::*;
 use crate::input::utils;
-use audiopus::Bitrate;
+use opus2::Bitrate;
 use std::{mem, time::Duration};
 use streamcatcher::{Config as ScConfig, GrowthStrategy};
 
@@ -23,7 +23,7 @@ pub fn compressed_cost_per_sec(bitrate: Bitrate) -> usize {
     let framing_cost_per_sec = AUDIO_FRAME_RATE * mem::size_of::<u16>();
 
     let bitrate_raw = match bitrate {
-        Bitrate::BitsPerSecond(i) => i,
+        Bitrate::Bits(i) => i,
         Bitrate::Auto => 64_000,
         Bitrate::Max => 512_000,
     } as usize;

--- a/src/input/codecs/dca/mod.rs
+++ b/src/input/codecs/dca/mod.rs
@@ -285,11 +285,13 @@ impl FormatReader for DcaReader {
 
         let buf = self.source.read_boxed_slice_exact(p_len as usize)?;
 
-        let checked_buf = buf[..].try_into().or_else(|_| {
-            symph_err::decode_error("Packet was not a valid Opus Packet: too large for audiopus.")
-        })?;
+        if buf.is_empty() || buf.len() > i32::MAX as usize {
+            return symph_err::decode_error(
+                "Packet was not a valid Opus packet: too large for opus2.",
+            );
+        }
 
-        let sample_ct = audiopus::packet::nb_samples(checked_buf, SAMPLE_RATE).or_else(|_| {
+        let sample_ct = opus2::packet::get_nb_samples(&buf, SAMPLE_RATE).or_else(|_| {
             symph_err::decode_error(
                 "Packet was not a valid Opus packet: couldn't read sample count.",
             )

--- a/src/input/codecs/mod.rs
+++ b/src/input/codecs/mod.rs
@@ -12,7 +12,7 @@ use symphonia::{
     default::*,
 };
 
-/// Default Symphonia [`CodecRegistry`], including the (audiopus-backed) Opus codec.
+/// Default Symphonia [`CodecRegistry`], including the (opus2-backed) Opus codec.
 pub fn get_codec_registry() -> &'static CodecRegistry {
     static CODEC_REGISTRY: OnceLock<CodecRegistry> = OnceLock::new();
     CODEC_REGISTRY.get_or_init(|| {

--- a/src/input/codecs/opus.rs
+++ b/src/input/codecs/opus.rs
@@ -38,9 +38,7 @@ impl OpusDecoder {
                 return decode_error("Opus packet was too large (greater than i32::MAX bytes).");
             }
 
-            let out_space = (&mut self.rawbuf[..]).try_into().expect("The following logic expands this buffer safely below i32::MAX, and we throw our own error.");
-
-            match self.inner.decode_float(packet.buf(), out_space, false) {
+            match self.inner.decode_float(packet.buf(), &mut self.rawbuf, false) {
                 Ok(v) => break v,
                 Err(e) if e.code() == ErrorCode::BufferTooSmall => {
                     // double the buffer size

--- a/src/input/codecs/opus.rs
+++ b/src/input/codecs/opus.rs
@@ -36,7 +36,7 @@ impl OpusDecoder {
         let s_ct = loop {
             if packet.buf().len() > i32::MAX as usize {
                 return decode_error("Opus packet was too large (greater than i32::MAX bytes).");
-            };
+            }
 
             let out_space = (&mut self.rawbuf[..]).try_into().expect("The following logic expands this buffer safely below i32::MAX, and we throw our own error.");
 

--- a/src/input/codecs/opus.rs
+++ b/src/input/codecs/opus.rs
@@ -1,10 +1,5 @@
 use crate::constants::*;
-use audiopus::{
-    coder::{Decoder as AudiopusDecoder, GenericCtl},
-    Channels,
-    Error as OpusError,
-    ErrorCode,
-};
+use opus2::{Channels, Decoder as Opus2Decoder, ErrorCode};
 use symphonia_core::{
     audio::{AsAudioBufferRef, AudioBuffer, AudioBufferRef, Layout, Signal, SignalSpec},
     codecs::{
@@ -19,9 +14,9 @@ use symphonia_core::{
     formats::Packet,
 };
 
-/// Opus decoder for symphonia, based on libopus v1.3 (via [`audiopus`]).
+/// Opus decoder for symphonia, based on libopus v1.5 (via [`opus2`]).
 pub struct OpusDecoder {
-    inner: AudiopusDecoder,
+    inner: Opus2Decoder,
     params: CodecParameters,
     buf: AudioBuffer<f32>,
     rawbuf: Vec<f32>,
@@ -39,18 +34,15 @@ unsafe impl Sync for OpusDecoder {}
 impl OpusDecoder {
     fn decode_inner(&mut self, packet: &Packet) -> SymphResult<()> {
         let s_ct = loop {
-            let pkt = if packet.buf().is_empty() {
-                None
-            } else if let Ok(checked_pkt) = packet.buf().try_into() {
-                Some(checked_pkt)
-            } else {
+            if packet.buf().len() > i32::MAX as usize {
                 return decode_error("Opus packet was too large (greater than i32::MAX bytes).");
             };
+
             let out_space = (&mut self.rawbuf[..]).try_into().expect("The following logic expands this buffer safely below i32::MAX, and we throw our own error.");
 
-            match self.inner.decode_float(pkt, out_space, false) {
+            match self.inner.decode_float(packet.buf(), out_space, false) {
                 Ok(v) => break v,
-                Err(OpusError::Opus(ErrorCode::BufferTooSmall)) => {
+                Err(e) if e.code() == ErrorCode::BufferTooSmall => {
                     // double the buffer size
                     // correct behav would be to mirror the decoder logic in the udp_rx set.
                     let new_size = (self.rawbuf.len() * 2).min(i32::MAX as usize);
@@ -88,7 +80,7 @@ impl OpusDecoder {
 
 impl Decoder for OpusDecoder {
     fn try_new(params: &CodecParameters, _options: &DecoderOptions) -> SymphResult<Self> {
-        let inner = AudiopusDecoder::new(SAMPLE_RATE, Channels::Stereo).unwrap();
+        let inner = Opus2Decoder::new(SAMPLE_RATE, Channels::Stereo).unwrap();
 
         let mut params = params.clone();
         params.with_sample_rate(SAMPLE_RATE_RAW as u32);
@@ -108,7 +100,7 @@ impl Decoder for OpusDecoder {
         &[symphonia_core::support_codec!(
             CODEC_TYPE_OPUS,
             "opus",
-            "libopus (1.3+, audiopus)"
+            "libopus (1.5+, opus2)"
         )]
     }
 

--- a/src/input/codecs/opus.rs
+++ b/src/input/codecs/opus.rs
@@ -38,7 +38,10 @@ impl OpusDecoder {
                 return decode_error("Opus packet was too large (greater than i32::MAX bytes).");
             }
 
-            match self.inner.decode_float(packet.buf(), &mut self.rawbuf, false) {
+            match self
+                .inner
+                .decode_float(packet.buf(), &mut self.rawbuf, false)
+            {
                 Ok(v) => break v,
                 Err(e) if e.code() == ErrorCode::BufferTooSmall => {
                     // double the buffer size

--- a/src/input/utils.rs
+++ b/src/input/utils.rs
@@ -1,7 +1,7 @@
 //! Utility methods for seeking or decoding.
 
 use crate::constants::*;
-use audiopus::{coder::Decoder, Channels, Result as OpusResult, SampleRate};
+use opus2::{Channels, Decoder, Result as OpusResult};
 use std::{mem, time::Duration};
 
 /// Calculates the sample position in a `FloatPCM` stream from a timestamp.
@@ -35,7 +35,7 @@ pub fn byte_count_to_timestamp(amt: usize, stereo: bool) -> Duration {
 /// Create an Opus decoder outputting at a sample rate of 48kHz.
 pub fn decoder(stereo: bool) -> OpusResult<Decoder> {
     Decoder::new(
-        SampleRate::Hz48000,
+        48000,
         if stereo {
             Channels::Stereo
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ## Codec support
 //! Songbird supports all [codecs and formats provided by Symphonia] (pure-Rust), with Opus support
-//! provided by [audiopus] (an FFI wrapper for libopus).
+//! provided by [opus2] (an FFI wrapper for libopus).
 //!
 //! **By default, *Songbird will not request any codecs from Symphonia*.** To change this, in your own
 //! project you will need to depend on Symphonia as well.
@@ -59,7 +59,7 @@
 //! [`ConnectionInfo`]: struct@ConnectionInfo
 //! [lavalink]: https://github.com/freyacodes/Lavalink
 //! [codecs and formats provided by Symphonia]: https://github.com/pdeljanov/Symphonia#formats-demuxers
-//! [audiopus]: https://github.com/lakelezz/audiopus
+//! [opus2]: https://github.com/cijiugechu/opus2
 
 #![warn(clippy::pedantic, rust_2018_idioms)]
 #![allow(


### PR DESCRIPTION
Lightly tested on both send and receive. `opus2` is not compatible with `audiopus`, so this is breaking, since Songbird re-exports `audiopus`:
- `Packet` newtype is dropped and `opus2` takes a byte slice directly. An empty byte slice is used to represent packet loss. Also means that packet length checks have to be done manually.
- `Bitrate::BitsPerSecond` -> `Bitrate::Bits`
- `SampleRate` enum is dropped in favor of a simple `u32`.
- Some other module changes (e.g. `audiopus::coder::Decoder` -> `opus2::Decoder`)