### PR TITLE
remove duplicate key nonmax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ twilight-model = { default-features = false, optional = true, version = ">= 0.16
 typenum = { optional = true, version = "1.17.0" }
 url = { optional = true, version = "2" }
 uuid = { features = ["v4"], optional = true, version = "1" }
-nonmax = "0.5.5"
 enum-map = "2.7.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes the following error:
```
error: duplicate key
  --> ../../.cargo/git/checkouts/songbird-f35e179d3fad55dd/763f39f/Cargo.toml:76:1
   |
76 | nonmax = "0.5.5"
   | ^^^^^^
error: no matching package named `songbird` found
location searched: Git repository https://github.com/serenity-rs/songbird?branch=serenity-next
```