### PR TITLE
Replace `doc_auto_cfg` with `doc_cfg` for docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
     html_logo_url = "https://raw.githubusercontent.com/serenity-rs/songbird/current/songbird.png",
     html_favicon_url = "https://raw.githubusercontent.com/serenity-rs/songbird/current/songbird-ico.png"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 //! ![project logo][logo]


### PR DESCRIPTION
The `doc_auto_cfg` feature was removed in Rust 1.92 and merged into `doc_cfg` (https://github.com/rust-lang/rust/pull/138907).