### PR TITLE
Allow connecting without any retries

### DIFF
--- a/src/driver/retry/mod.rs
+++ b/src/driver/retry/mod.rs
@@ -2,8 +2,6 @@
 
 mod strategy;
 
-use nonmax::NonMaxU8;
-
 pub use self::strategy::*;
 
 use crate::FloatDuration;
@@ -24,14 +22,14 @@ pub struct Retry {
     /// while `Some(0)` will attempt to connect *once* (no retries).
     ///
     /// *Defaults to `Some(5)`.*
-    pub retry_limit: Option<NonMaxU8>,
+    pub retry_limit: Option<u8>,
 }
 
 impl Default for Retry {
     fn default() -> Self {
         Self {
             strategy: Strategy::Backoff(ExponentialBackoff::default()),
-            retry_limit: Some(const { NonMaxU8::new(5).unwrap() }),
+            retry_limit: Some(5),
         }
     }
 }

--- a/src/driver/retry/mod.rs
+++ b/src/driver/retry/mod.rs
@@ -40,7 +40,7 @@ impl Retry {
         last_wait: Option<FloatDuration>,
         attempts: u8,
     ) -> Option<FloatDuration> {
-        if self.retry_limit.is_none_or(|a| attempts < a.get()) {
+        if self.retry_limit.is_none_or(|a| attempts < a) {
             Some(self.strategy.retry_in(last_wait))
         } else {
             None

--- a/src/driver/retry/mod.rs
+++ b/src/driver/retry/mod.rs
@@ -2,9 +2,9 @@
 
 mod strategy;
 
-pub use self::strategy::*;
+use nonmax::NonMaxU8;
 
-use std::num::NonZeroU8;
+pub use self::strategy::*;
 
 use crate::FloatDuration;
 
@@ -24,14 +24,14 @@ pub struct Retry {
     /// while `Some(0)` will attempt to connect *once* (no retries).
     ///
     /// *Defaults to `Some(5)`.*
-    pub retry_limit: Option<NonZeroU8>,
+    pub retry_limit: Option<NonMaxU8>,
 }
 
 impl Default for Retry {
     fn default() -> Self {
         Self {
             strategy: Strategy::Backoff(ExponentialBackoff::default()),
-            retry_limit: Some(const { NonZeroU8::new(5).unwrap() }),
+            retry_limit: Some(const { NonMaxU8::new(5).unwrap() }),
         }
     }
 }


### PR DESCRIPTION
Use `u8` instead of `NonZeroU8` for specifying number of retries, so `Some(0)` can be specified again to indicate that no retrying is desired.

Closes #302 