### PR TITLE
User YTDL args overrides hardcoded ones

### DIFF
--- a/src/input/sources/ytdl.rs
+++ b/src/input/sources/ytdl.rs
@@ -140,8 +140,8 @@ impl<'a> YoutubeDl<'a> {
         ];
 
         let output = Command::new(self.program)
-            .args(self.user_args.clone())
             .args(ytdl_args)
+            .args(self.user_args.clone())
             .output()
             .await
             .map_err(|e| {


### PR DESCRIPTION
Fixes #306, whose functionality was added in #268

Swapped application order of the hardcoded args and user args to give user control over the hardcoded args.